### PR TITLE
Fixing Qt auto-docs using conda

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,7 +2,8 @@ formats:
         - epub
         - pdf
 
-requirements_file: requirements/docs.txt
+conda:
+    file: requirements/conda.yml
 
 python:
    version: 3

--- a/requirements/conda.yml
+++ b/requirements/conda.yml
@@ -1,0 +1,32 @@
+name: pymeasure
+dependencies:
+- fontconfig=2.11.1=5
+- freetype=2.5.5=0
+- libpng=1.6.17=0
+- libxml2=2.9.2=0
+- mkl=11.3.3=0
+- numpy=1.11.0=py35_1
+- openssl=1.0.2h=1
+- pandas=0.18.1=np111py35_0
+- pip=8.1.1=py35_1
+- py=1.4.31=py35_0
+- pyqt=4.11.4=py35_2
+- pyqtgraph=0.9.10=py35_1
+- pyserial=2.7=py35_0
+- pytest=2.9.1=py35_0
+- python=3.5.1=0
+- python-dateutil=2.5.3=py35_0
+- pytz=2016.4=py35_0
+- qt=4.8.7=2
+- readline=6.2=2
+- setuptools=21.2.1=py35_0
+- sip=4.16.9=py35_0
+- six=1.10.0=py35_0
+- sqlite=3.13.0=0
+- tk=8.5.18=0
+- wheel=0.29.0=py35_0
+- xz=5.0.5=1
+- zlib=1.2.8=3
+- pip:
+  - pyvisa==1.8
+


### PR DESCRIPTION
Currently the Qt section of the docs does not build properly because the Qt libraries can not be easily installed with pip. This replaces the ReadTheDocs (RTD) environment with conda, which can easily include Qt.