### PR TITLE
Add instructions on how to install with conda

### DIFF
--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -19,12 +19,31 @@ Download and install the appropriate Python 3.5 version of `Anaconda`_ for your 
 Installing PyMeasure
 ====================
 
-Now that you have Python installed, open up a "Jupyter Notebook". We will use this notebook to install the PyMeasure package with :code:`pip`, which you can alternatively do in the command-line. Run the following code in the notebook (here the "!" tells the notebook to run a terminal command instead of regular Python):
+Install with conda
+------------------
+
+Now that you have Python installed, open up a "Jupyter Notebook". We will use this notebook to install the PyMeasure package with :code:`conda`, which you can alternatively do in the command-line. Run the following code in the notebook (here the "!" tells the notebook to run a terminal command instead of regular Python):
+
+.. code-block:: none
+
+   > !conda config --add channels conda-forge
+   > !conda install xonsh
+
+This will install PyMeasure and all the required dependencies. 
+
+Install with ``pip``
+--------------------
+
+If you don't have the conda package manager (i.e. you don't use the `Anaconda distribution`_ ) you can also install PyMeasure using :code:`pip`.
 
 .. code-block:: none
     
     !pip install pymeasure
 
+    
+Check that it works
+-------------------
+   
 In another cell of the notebook, we can check the version number of PyMeasure by executing the following.
 
 .. code-block:: python

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -26,8 +26,8 @@ Now that you have Python installed, open up a "Jupyter Notebook". We will use th
 
 .. code-block:: none
 
-   > !conda config --add channels conda-forge
-   > !conda install xonsh
+   !conda config --add channels conda-forge
+   !conda install xonsh
 
 This will install PyMeasure and all the required dependencies. 
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -22,29 +22,32 @@ Installing PyMeasure
 Install with conda
 ------------------
 
-Now that you have Python installed, open up a "Jupyter Notebook". We will use this notebook to install the PyMeasure package with :code:`conda`, which you can alternatively do in the command-line. Run the following code in the notebook (here the "!" tells the notebook to run a terminal command instead of regular Python):
+If you have the `Anaconda distribution`_ you can use the conda package mangager to easily install PyMeasure and all required dependencies.  
+Open a terminal and type the following commands (On windows look for the `Anaconda Prompt` in the start menu). :
 
-.. code-block:: none
+.. code-block:: bash
 
-   !conda config --add channels conda-forge
-   !conda install xonsh
+   > conda config --add channels conda-forge
+   > conda install pymeasure
 
 This will install PyMeasure and all the required dependencies. 
 
 Install with ``pip``
 --------------------
 
-If you don't have the conda package manager (i.e. you don't use the `Anaconda distribution`_ ) you can also install PyMeasure using :code:`pip`.
+PyMeasure can also be installed with :code:`pip`. 
 
-.. code-block:: none
+.. code-block:: bash
     
-    !pip install pymeasure
+    > pip install pymeasure
+ 
+Note, that this may involve some extra work inorder manage all dependencies.
 
     
 Check that it works
 -------------------
-   
-In another cell of the notebook, we can check the version number of PyMeasure by executing the following.
+
+Now that you have Python and PyMeasure installed, open up a "Jupyter Notebook" to test it.  Try to run the following code in the notebook.
 
 .. code-block:: python
 


### PR DESCRIPTION
I  have added instructions on how to install with conda. 

I think the install instructions would be simpler if you didn't suggest doing the install through a notebook. I haven't changed that though...

