### PR TITLE
Adding GMW 5201 and 5403 electromagnets

### DIFF
--- a/docs/api/instruments/gmw/gmw5201.rst
+++ b/docs/api/instruments/gmw/gmw5201.rst
@@ -1,0 +1,7 @@
+######################################
+GMW 5201 Projected Field Electromagnet
+######################################
+
+.. autoclass:: pymeasure.instruments.gmw.GMW5201
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/gmw/gmw5403.rst
+++ b/docs/api/instruments/gmw/gmw5403.rst
@@ -1,0 +1,7 @@
+##############################
+GMW 5403 C-Frame Electromagnet
+##############################
+
+.. autoclass:: pymeasure.instruments.gmw.GMW5403
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/gmw/index.rst
+++ b/docs/api/instruments/gmw/index.rst
@@ -1,0 +1,13 @@
+.. module:: pymeasure.instruments.gmw
+
+##############
+GMW Associates
+##############
+
+This section contains specific documentation on the GWM Associates instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   gmw5201
+   gmw5403

--- a/docs/api/instruments/index.rst
+++ b/docs/api/instruments/index.rst
@@ -23,6 +23,7 @@ Instruments by manufacturer:
    danfysik/index
    fwbell/index
    hp/index
+   gmw/index
    keithley/index
    lakeshore/index
    parker/index

--- a/pymeasure/instruments/gmw/__init__.py
+++ b/pymeasure/instruments/gmw/__init__.py
@@ -1,0 +1,26 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2016 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .gmw5201 import GMW5201
+from .gmw5403 import GMW5403

--- a/pymeasure/instruments/gmw/gmw5201.py
+++ b/pymeasure/instruments/gmw/gmw5201.py
@@ -1,0 +1,43 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2016 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+from pymeasure.instruments import Instrument
+
+
+class GMW5201(Instrument):
+    """ Represents the GMW 5201 Projected Field Electromagnet
+    and provides a high-level interface for interacting
+    with the instrument.
+    """
+
+    def __init__(self, resourceName, **kwargs):
+        super(GMW5201, self).__init__(
+            resourceName,
+            "GMW 5201 Projected Field Electromagnet",
+            **kwargs
+        )

--- a/pymeasure/instruments/gmw/gmw5403.py
+++ b/pymeasure/instruments/gmw/gmw5403.py
@@ -1,0 +1,43 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2016 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+from pymeasure.instruments import Instrument
+
+
+class GMW5403(Instrument):
+    """ Represents the GMW 5403 C-Frame Electromagnet
+    and provides a high-level interface for interacting
+    with the instrument.
+    """
+
+    def __init__(self, resourceName, **kwargs):
+        super(GMW5403, self).__init__(
+            resourceName,
+            "GMW 5403 C-Frame Electromagnet",
+            **kwargs
+        )

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'pymeasure.instruments.danfysik',
         'pymeasure.instruments.fwbell',
         'pymeasure.instruments.hp',
+        'pymeasure.instruments.gmw',
         'pymeasure.instruments.keithley',
         'pymeasure.instruments.lakeshore',
         'pymeasure.instruments.parker',


### PR DESCRIPTION
Following the addition of the Newport ESP 300 Motor Controller in #42, the GMW 5201 Projected Field Electromagnet can be defined. This PR also includes the GMW 5403 C-Frame Electromagnet, which share common attributes and methods. Code is based partially on Graham's previous work in the previous commit 1c4153e7d2a9a896fcfbb1964fdcfd47f31aaf32, specifically [magnet.py](https://github.com/ralph-group/pymeasure/blob/1c4153e7d2a9a896fcfbb1964fdcfd47f31aaf32/control/instruments/magnet.py).
