### PR TITLE
Updating FWBell5080

### DIFF
--- a/pymeasure/instruments/fwbell/fwbell5080.py
+++ b/pymeasure/instruments/fwbell/fwbell5080.py
@@ -23,7 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument, RangeException
-from pymeasure.instruments.validators import truncated_discrete_set
+from pymeasure.instruments.validators import truncated_discrete_set, strict_discrete_set
 from pymeasure.adapters import SerialAdapter
 from numpy import array, float64
 
@@ -34,25 +34,44 @@ class FWBell5080(Instrument):
     instrument
 
     :param port: The serial port of the instrument
+
+    .. code-block:: python
+
+        meter = FWBell5080('/dev/ttyUSB0')      # Connects over serial port /dev/ttyUSB0 (Linux)
+
+        meter.units = 'gauss'                   # Sets the measurement units to Gauss
+        meter.range = 3e3                       # Sets the range to 3 kG
+        print(meter.field)                      # Reads and prints a field measurement in G
+
+        fields = meter.fields(100)              # Samples 100 field measurements
+        print(fields.mean(), fields.std())      # Prints the mean and standard deviation of the samples
+
     """
 
     id = Instrument.measurement(
         "*IDN?", """ Reads the idenfitication information. """
     )
-    units = Instrument.measurement(
-        ":UNIT:FLUX?",
-        """ Reads the units being used
-        """
+    field = Instrument.measurement(
+        ":MEAS:FLUX?",
+        """ Reads a floating point value of the field in the appropriate units.
+        """,
+        get_process=lambda v: v.split(' ')[0] # Remove units
     )
-    range = Instrument.control(
-        ":SENS:FLUX:RANG?", ":SENS:FLUX:RANG %d",
-        """ A floating point property that controls the maximum field
-        range in Gauss, which can take the values 300, 3,000, and 
-        30,000 G. Values outside these are truncated to the closest
-        valid value. This property can be set. """,
-        validator=truncated_discrete_set,
-        values={300:0, 3000:1, 30000:2},
-        map_values=True
+    UNITS = {
+        'gauss':'DC:GAUSS', 'gauss ac':'AC:GAUSS',
+        'tesla':'DC:TESLA', 'tesla ac':'AC:TESLA',
+        'amp-meter':'DC:AM', 'amp-meter ac':'AC:AM'
+    }
+    units = Instrument.control(
+        ":UNIT:FLUX?", ":UNIT:FLUX%s",
+        """ A string property that controls the field units, which can take the
+        values: 'gauss', 'gauss ac', 'tesla', 'tesla ac', 'amp-meter', and
+        'amp-meter ac'. The AC versions configure the instrument to measure AC.
+        """,
+        validator=strict_discrete_set,
+        values=UNITS,
+        map_values=True,
+        get_process=lambda v: v.replace(' ', ':') # Make output consistent with input
     )
 
     def __init__(self, port):
@@ -61,60 +80,64 @@ class FWBell5080(Instrument):
             "F.W. Bell 5080 Handheld Gaussmeter"
         )
 
+    @property
+    def range(self):
+        """ A floating point property that controls the maximum field
+        range in the active units. This can take the values of 300 G,
+        3 kG, and 30 kG for Gauss, 30 mT, 300 mT, and 3 T for Tesla,
+        and 23.88 kAm, 238.8 kAm, and 2388 kAm for Amp-meter. """
+        i = self.values(":SENS:FLUX:RANG?", cast=int)
+        units = self.units
+        if 'gauss' in self.units:
+            return [300, 3e3, 30e3][i]
+        elif 'tesla' in self.units:
+            return [30e-3, 300e-3, 3][i]
+        elif 'amp-meter' in self.units:
+            return [23.88e3, 238.8e3, 2388e3][i]
+
+    @range.setter
+    def range(self, value):
+        units = self.units
+        if 'gauss' in self.units:
+            i = truncated_discrete_set(value, [300, 3e3, 30e3])
+        elif 'tesla' in self.units:
+            i = truncated_discrete_set(value, [30e-3, 300e-3, 3])
+        elif 'amp-meter' in self.units:
+            i = truncated_discrete_set(value, [23.88e3, 238.8e3, 2388e3])
+        self.write(":SENS:FLUX:RANG %d" % i)
+
     def read(self):
-        """ Overwrites the standard read method to remove the last
-        2 characters from the output
+        """ Overwrites the :meth:`Instrument.read <pymeasure.instruments.Instrument.read>` 
+        method to remove the last 2 characters from the output.
         """
         return super(FWBell5080, self).read()[:-2]
 
-    def ask(self):
-        """ Overwrites the standard ask method to remove the last
-        2 characters from the output
+    def ask(self, command):
+        """ Overwrites the :meth:`Instrument.ask <pymeasure.instruments.Instrument.ask>`
+        method to remove the last 2 characters from the output.
         """
         return super(FWBell5080, self).ask()[:-2]
 
-    def reset(self):
-        """ Resets the instrument.
+    def values(self, command):
+        """ Overwrites the :meth:`Instrument.values <pymeasure.instruments.Instrument.values>` 
+        method to remove the lastv2 characters from the output.
         """
+        return super(FWBell5080, self).values()[:-2]
+
+    def reset(self):
+        """ Resets the instrument. """
         self.write("*OPC")
 
-    def measure(self, averages=1):
-        """ Returns the measured field over a certain number of averages
-        in Gauss and the standard deviation in the averages if measured in
-        Gauss or Tesla. Raise an exception if set in Ampere meter units.
+    def fields(self, samples=1):
+        """ Returns a numpy array of field samples for a given sample number.
 
-        :param averages: The number of averages to preform
+        :param samples: The number of samples to preform
         """
-        if averages == 1:
-            value = self.ask(":MEAS:FLUX?")
-            if value[-1] == "G":  # Field in gauss
-                return (float(value[:-1]), 0)
-            elif value[-1] == "T":  # Field in tesla
-                return (float(value[:-1])*1e4, 0)
-            elif value[-2:] == "Am":  # Field in Ampere meters
-                raise Exception("Field is being measured in Ampere meters "
-                                "instead of guass and measure() should not "
-                                "be used")
+        if samples < 1:
+            raise Exception("F.W. Bell 5080 does not support samples less than 1.")
         else:
-            data = [self.measure()[0] for point in range(averages)]
-            data = array(data, dtype=float64)
-            return (data.mean(), data.std())
-
-    def use_DC_gauss(self):
-        """ Sets the meter to measure DC fields in Gauss. """
-        self.write(":UNIT:FLUX:DC:GAUS")
-
-    def use_AC_gauss(self):
-        """ Sets the meter to measure AC fields in Gauss. """
-        self.write(":UNIT:FLUX:AC:GAUS")
-
-    def use_DC_tesla(self):
-        """ Sets the meter to measure DC fields in Tesla. """
-        self.write(":UNIT:FLUX:DC:TESL")
-
-    def use_AC_tesla(self):
-        """ Sets the meter to measure AC fields in Tesla. """
-        self.write(":UNIT:FLUX:AC:TESL")
+            data = [self.field for i in range(int(samples))]
+            return array(data, dtype=float64)
 
     def auto_range(self):
         """ Enables the auto range functionality. """


### PR DESCRIPTION
This PR updates the F.W. Bell 5080 Handheld Gaussmeter with more unit agnostic features (i.e. not biased towards Gauss), and adds more documentation to the class. This relies on the `get_process` parameter of `Instrument.control` added in #40, so that must be merged first.