### PR TITLE
Fix pip install by including CHANGES.txt in MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include setup.py
 include README.rst
 include LICENSE.txt
+include CHANGES.txt
 recursive-include pymeasure *


### PR DESCRIPTION
This PR addresses #71, where the `CHANGES.txt` file is not found during basic `pip` install.