### PR TITLE
Fixup docs for resources

### DIFF
--- a/docs/api/instruments/resources.rst
+++ b/docs/api/instruments/resources.rst
@@ -4,5 +4,4 @@ Resource Manager
 
 The list_resources function provides an interface to check connected instruments interactively.
 
-.. automodule:: pymeasure.instruments.list_resources
-   :members:
+.. autofunction:: pymeasure.instruments.list_resources


### PR DESCRIPTION
`list_resources` is a function, not a module, which triggers the following error message when running Sphinx:
```
/<<PKGBUILDDIR>>/pymeasure/instruments/keithley/keithley2400.py:docstring of pymeasure.instruments.keithley.Keithley2400.trigger_on_bus:1: WARNING: Inline emphasis start-string without end-string.
/<<PKGBUILDDIR>>/docs/api/instruments/resources.rst:7: WARNING: autodoc: failed to import module 'pymeasure.instruments.list_resources'; the following exception was raised:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sphinx/ext/autodoc.py", line 529, in import_object
    __import__(self.modname)
ImportError: No module named 'pymeasure.instruments.list_resources'
```