### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,17 @@ matrix:
     - os: linux
       env: PYTHON=3.5  CONDA_PY=35
       sudo: true
+    - os: linux
+      env: PYTHON=3.6  CONDA_PY=36
+      sudo: true
     - os: osx
       env: PYTHON=3.4  CONDA_PY=34
       sudo: false
     - os: osx
       env: PYTHON=3.5  CONDA_PY=35
+      sudo: false
+    - os: osx
+      env: PYTHON=3.6  CONDA_PY=36
       sudo: false
 
 # command to install dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,13 @@ environment:
       #PYTHON_ARCH: "64"
       PLATFORM: x64
 
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36-x64
+      #PYTHON: "C:\\Python36-x64"
+      #DISTUTILS_USE_SDK: "1"
+      #PYTHON_ARCH: "64"
+      PLATFORM: x64
+
     # 32-bit
     - PYTHON_VERSION: "3.4"
       MINICONDA: C:\Miniconda3
@@ -34,6 +41,11 @@ environment:
     - PYTHON_VERSION: "3.5"
       MINICONDA: C:\Miniconda35
       #PYTHON: "C:\\Python35"
+      PLATFORM: x86
+
+    - PYTHON_VERSION: "3.6"
+      MINICONDA: C:\Miniconda36
+      #PYTHON: "C:\\Python36"
       PLATFORM: x86
 
 skip_tags: true

--- a/conftest.py
+++ b/conftest.py
@@ -27,4 +27,4 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true",
-        help="run slow tests")
+                     help="run slow tests")

--- a/pymeasure/adapters/__init__.py
+++ b/pymeasure/adapters/__init__.py
@@ -22,10 +22,11 @@
 # THE SOFTWARE.
 #
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 from .adapter import Adapter, FakeAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 try:
     from pymeasure.adapters.visa import VISAAdapter

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -73,8 +73,8 @@ class Adapter(object):
         for i, result in enumerate(results):
             try:
                 results[i] = cast(result)
-            except:
-                pass # Keep as string
+            except Exception:
+                pass  # Keep as string
         return results
 
     def binary_values(self, command, header_bytes=0, dtype=np.float32):

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -22,10 +22,15 @@
 # THE SOFTWARE.
 #
 
-from .adapter import Adapter
+import logging
 
 import serial
 import numpy as np
+
+from .adapter import Adapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class SerialAdapter(Adapter):
@@ -37,7 +42,10 @@ class SerialAdapter(Adapter):
     """
 
     def __init__(self, port, **kwargs):
-        self.connection = serial.Serial(port, **kwargs)
+        if isinstance(port, serial.Serial):
+            self.connection = port
+        else:
+            self.connection = serial.Serial(port, **kwargs)
 
     def __del__(self):
         """ Ensures the connection is closed upon deletion
@@ -49,7 +57,7 @@ class SerialAdapter(Adapter):
 
         :param command: SCPI command string to be sent to the instrument
         """
-        self.connection.write(command.encode()) # encode added for Python 3
+        self.connection.write(command.encode())  # encode added for Python 3
 
     def read(self):
         """ Reads until the buffer is empty and returns the resulting

--- a/pymeasure/adapters/tests/test_adapter.py
+++ b/pymeasure/adapters/tests/test_adapter.py
@@ -22,7 +22,12 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from pymeasure.adapters import FakeAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def test_adapter_values():

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -22,15 +22,19 @@
 # THE SOFTWARE.
 #
 
-from .adapter import Adapter
+import logging
 
+import copy
 import visa
 import numpy as np
-import copy
-import logging
+
+from .adapter import Adapter
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+
+# noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
     """ Adapter class for the VISA library using PyVISA to communicate
     to instruments. Inherit from either class VISAAdapter14 or VISAAdapter15.
@@ -38,11 +42,14 @@ class VISAAdapter(Adapter):
     :param resource: VISA resource name that identifies the address
     :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
     """
+
     def __init__(self, resourceName, **kwargs):
-        #Check PyVisa version
+        # Check PyVisa version
         version = float(self.version)
         if version < 1.7:
-            raise NotImplementedError("PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(version))
+            raise NotImplementedError(
+                "PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(
+                    version))
 
         if isinstance(resourceName, int):
             resourceName = "GPIB0::%d::INSTR" % resourceName
@@ -57,9 +64,10 @@ class VISAAdapter(Adapter):
             if key not in safeKeywords:
                 kwargs.pop(key)
         self.connection = self.manager.get_instrument(
-                                resourceName,
-                                **kwargs
-                          )
+            resourceName,
+            **kwargs
+        )
+
     @property
     def version(self):
         """ The string of the PyVISA version in use
@@ -119,9 +127,9 @@ class VISAAdapter(Adapter):
         header, data = binary[:header_bytes], binary[header_bytes:]
         return np.fromstring(data, dtype=dtype)
 
-    def config(self, is_binary = False, datatype = 'str',
-                    container = np.array, converter = 's',
-                    separator = ',', is_big_endian = False):
+    def config(self, is_binary=False, datatype='str',
+               container=np.array, converter='s',
+               separator=',', is_big_endian=False):
         """ Configurate the format of data transfer to and from the instrument.
 
         :param is_binary: If True, data is in binary format, otherwise ASCII.
@@ -132,12 +140,11 @@ class VISAAdapter(Adapter):
         :param is_big_endian: Endianness.
         """
         self.connection.values_format.is_binary = is_binary
-        self.connection.values_format.datatype  = datatype
+        self.connection.values_format.datatype = datatype
         self.connection.values_format.container = container
         self.connection.values_format.converter = converter
         self.connection.values_format.separator = separator
         self.connection.values_format.is_big_endian = is_big_endian
-
 
     def wait_for_srq(self, timeout=25, delay=0.1):
         """ Blocks until a SRQ, and leaves the bit high
@@ -145,4 +152,4 @@ class VISAAdapter(Adapter):
         :param timeout: Timeout duration in seconds
         :param delay: Time delay between checking SRQ in seconds
         """
-        self.connection.wait_for_srq(timeout*1000)
+        self.connection.wait_for_srq(timeout * 1000)

--- a/pymeasure/console.py
+++ b/pymeasure/console.py
@@ -23,11 +23,13 @@
 #
 
 import logging
+
+import numpy as np
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-import numpy as np
-from datetime.datetime import now
+log.warning('not implemented yet')
 
 
 class ProgressBar(object):
@@ -38,7 +40,7 @@ class ProgressBar(object):
 
     def __init__(self):
         self.data = np.empty()
-        self.progress_precents = []
+        self.progress_percentage = []
         self.progress_times = []
 
     def advance(self, progress):

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -22,19 +22,25 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from pyqtgraph.Qt import QtGui, QtCore, loadUiType
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 QtCore.QSignal = QtCore.pyqtSignal
+
 
 def fromUi(*args, **kwargs):
     """ Returns a Qt object constructed using loadUiType
     based on its arguments. All QWidget objects in the
     form class are set in the returned object for easy
-    accessiblity.
+    accessability.
     """
-    formClass, baseClass = loadUiType(*args, **kwargs)
-    widget = baseClass()
-    form = formClass()
+    form_class, base_class = loadUiType(*args, **kwargs)
+    widget = base_class()
+    form = form_class()
     form.setupUi(widget)
     form.retranslateUi(widget)
     for name in dir(form):

--- a/pymeasure/display/__init__.py
+++ b/pymeasure/display/__init__.py
@@ -22,6 +22,7 @@
 # THE SOFTWARE.
 #
 import logging
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -30,8 +31,6 @@ try:
     from .plotter import Plotter
 except ImportError:
     log.warning("Python bindings for Qt (PySide, PyQt) can not be imported")
-except Exception as e:
-    raise e
 
 
 def run_in_ipython(app):
@@ -41,6 +40,7 @@ def run_in_ipython(app):
     """
     try:
         from IPython.lib.guisupport import start_event_loop_qt4
-        start_event_loop_qt4(app)
     except ImportError:
         app.exec_()
+    else:
+        start_event_loop_qt4(app)

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -23,19 +23,19 @@
 #
 
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-from pymeasure.experiment import Procedure
-from .Qt import QtCore, QtGui
 
 from os.path import basename
 
+from .Qt import QtCore, QtGui
+from ..experiment import Procedure
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 
 class BrowserItem(QtGui.QTreeWidgetItem):
-
     def __init__(self, results, curve, parent=None):
-        super(BrowserItem, self).__init__(parent)
+        super().__init__(parent)
 
         pixelmap = QtGui.QPixmap(24, 24)
         pixelmap.fill(curve.opts['pen'].color())
@@ -87,7 +87,7 @@ class Browser(QtGui.QTreeWidget):
 
     def __init__(self, procedure_class, display_parameters,
                  measured_quantities, sort_by_filename=False, parent=None):
-        super(Browser, self).__init__(parent)
+        super().__init__(parent)
         self.display_parameters = display_parameters
         self.procedure_class = procedure_class
         self.measured_quantities = measured_quantities
@@ -125,7 +125,7 @@ class Browser(QtGui.QTreeWidget):
         item = experiment.browser_item
         for i, column in enumerate(self.display_parameters):
             if column in experiment_parameter_names:
-                item.setText(i+4, str(experiment_parameters[column]))
+                item.setText(i + 4, str(experiment_parameters[column]))
 
         self.addTopLevelItem(item)
         self.setItemWidget(item, 2, item.progressbar)

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -22,16 +22,24 @@
 # THE SOFTWARE.
 #
 
-from .Qt import QtCore, QtGui
+import logging
+
 import re
+
+from .Qt import QtCore, QtGui
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class Input(QtCore.QObject):
     """ Takes a Parameter object in the constructor and has a
     parameter method
-    """ 
-    
+    """
+
     def __init__(self, parameter):
+        super().__init__()
+        self._parameter = None
         self.set_parameter(parameter)
 
     def set_parameter(self, parameter):
@@ -50,9 +58,8 @@ class Input(QtCore.QObject):
 
 
 class StringInput(QtGui.QLineEdit, Input):
-    
     def __init__(self, parameter, parent=None):
-        QtGui.QLineEdit.__init__(self, parent=parent)
+        QtGui.QLineEdit.__init__(self, parent)
         Input.__init__(self, parameter)
         if self._parameter.default:
             self.setText(self._parameter.default)
@@ -66,9 +73,8 @@ class StringInput(QtGui.QLineEdit, Input):
 
 
 class FloatInput(QtGui.QDoubleSpinBox, Input):
-    
     def __init__(self, parameter, parent=None):
-        QtGui.QDoubleSpinBox.__init__(self, parent=parent)
+        QtGui.QDoubleSpinBox.__init__(self, parent)
         Input.__init__(self, parameter)
         self.setMinimum(self._parameter.minimum)
         self.setMaximum(self._parameter.maximum)
@@ -87,9 +93,8 @@ class FloatInput(QtGui.QDoubleSpinBox, Input):
 
 
 class IntegerInput(QtGui.QSpinBox, Input):
-    
     def __init__(self, parameter, parent=None):
-        QtGui.QSpinBox.__init__(self, parent=parent)
+        QtGui.QSpinBox.__init__(self, parent)
         Input.__init__(self, parameter)
         self.setMinimum(self._parameter.minimum)
         self.setMaximum(self._parameter.maximum)
@@ -107,20 +112,19 @@ class IntegerInput(QtGui.QSpinBox, Input):
         self._parameter.value = self.value()
 
 
-class BooleanInput():
+class BooleanInput(object):
     # TODO: Implement this class
     pass
 
 
-class ListInput():
+class ListInput(object):
     # TODO: Implement this class
     pass
 
 
 class ScientificInput(QtGui.QDoubleSpinBox, Input):
-
     def __init__(self, parameter, parent=None):
-        QtGui.QDoubleSpinBox.__init__(self, parent=parent)
+        QtGui.QDoubleSpinBox.__init__(self, parent)
         self.setMinimum(parameter.minimum)
         self.setMaximum(parameter.maximum)
         self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
@@ -146,7 +150,7 @@ class ScientificInput(QtGui.QDoubleSpinBox, Input):
         if self._parameter.units:
             text = text[:-(len(self._parameter.units) + 1)]
             result = self.validator.validate(text, pos)
-            return (result[0], result[1] + " %s" % self._parameter.units, result[2])
+            return result[0], result[1] + " %s" % self._parameter.units, result[2]
         else:
             return self.validator.validate(text, pos)
 

--- a/pymeasure/display/listeners.py
+++ b/pymeasure/display/listeners.py
@@ -23,21 +23,21 @@
 #
 
 import logging
+
+from .Qt import QtCore
+from .thread import StoppableQThread
+from ..experiment.procedure import Procedure
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-from .Qt import QtCore
-
 try:
     import zmq
-    from msgpack_numpy import loads
+    import cloudpickle
 except ImportError:
-    log.warning("ZMQ and MsgPack are required for TCP communication")
-
-from time import sleep
-
-from pymeasure.display.thread import StoppableQThread
-from pymeasure.experiment.procedure import Procedure
+    zmq = None
+    cloudpickle = None
+    log.warning("ZMQ and cloudpickle are required for TCP communication")
 
 
 class QListener(StoppableQThread):
@@ -47,13 +47,15 @@ class QListener(StoppableQThread):
     """
 
     def __init__(self, port, topic='', timeout=0.01):
-        """ Constructs the Listener object with a subscriber port 
+        """ Constructs the Listener object with a subscriber port
         over which to listen for messages
 
         :param port: TCP port to listen on
         :param topic: Topic to listen on
         :param timeout: Timeout in seconds to recheck stop flag
         """
+        super().__init__()
+
         self.port = port
         self.topic = topic
         self.context = zmq.Context()
@@ -67,11 +69,11 @@ class QListener(StoppableQThread):
         self.poller = zmq.Poller()
         self.poller.register(self.subscriber, zmq.POLLIN)
         self.timeout = timeout
-        super(QListener, self).__init__()
 
     def receive(self, flags=0):
-        topic, raw_data = self.subscriber.recv_multipart(flags=flags)
-        return topic.decode(), loads(raw_data, encoding='utf-8')
+        data = self.subscriber.recv_multipart(flags=flags)
+        topic, record = cloudpickle.loads(data)
+        return topic, record
 
     def message_waiting(self):
         return self.poller.poll(self.timeout)
@@ -84,7 +86,7 @@ class QListener(StoppableQThread):
 class Monitor(QtCore.QThread):
     """ Monitor listens for status and progress messages
     from a Worker through a queue to ensure no messages
-    are lost
+    are losts
     """
 
     status = QtCore.QSignal(int)
@@ -92,12 +94,12 @@ class Monitor(QtCore.QThread):
     log = QtCore.QSignal(object)
     worker_running = QtCore.QSignal()
     worker_failed = QtCore.QSignal()
-    worker_finished = QtCore.QSignal() # Distinguished from QThread.finished
+    worker_finished = QtCore.QSignal()  # Distinguished from QThread.finished
     worker_abort_returned = QtCore.QSignal()
 
     def __init__(self, queue):
+        super().__init__()
         self.queue = queue
-        super(Monitor, self).__init__()
 
     def run(self):
         while True:
@@ -121,8 +123,3 @@ class Monitor(QtCore.QThread):
                 self.log.emit(data)
 
         log.info("Monitor caught stop command")
-
-
-
-
-

--- a/pymeasure/display/log.py
+++ b/pymeasure/display/log.py
@@ -22,17 +22,22 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from logging import Handler
-from .Qt import QtCore, QtGui
+
+from .Qt import QtCore
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class LogHandler(QtCore.QObject, Handler):
-
     record = QtCore.QSignal(object)
 
     def __init__(self, parent=None):
+        QtCore.QObject.__init__(self, parent)
         Handler.__init__(self)
-        QtCore.QObject.__init__(self, parent=parent)
 
     def emit(self, record):
         self.record.emit(self.format(record))

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -23,17 +23,16 @@
 #
 
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-from .Qt import QtGui
-
-from ..process import StoppableProcess
-from .windows import PlotterWindow
 
 import sys
-from time import sleep
-import pyqtgraph as pg
+import time
+
+from .Qt import QtGui
+from .windows import PlotterWindow
+from ..process import StoppableProcess
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class Plotter(StoppableProcess):
@@ -55,4 +54,4 @@ class Plotter(StoppableProcess):
 
     def wait_for_close(self, check_time=0.1):
         while not self.should_stop():
-            sleep(check_time)
+            time.sleep(check_time)

--- a/pymeasure/display/thread.py
+++ b/pymeasure/display/thread.py
@@ -22,8 +22,14 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from threading import Event
+
 from .Qt import QtCore
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class StoppableQThread(QtCore.QThread):
@@ -32,9 +38,9 @@ class StoppableQThread(QtCore.QThread):
     """
 
     def __init__(self, parent=None):
+        super().__init__(parent)
         self._should_stop = Event()
         self._should_stop.clear()
-        super(StoppableQThread, self).__init__(parent)
 
     def join(self, timeout=0):
         """ Joins the current thread and forces it to stop after

--- a/pymeasure/errors.py
+++ b/pymeasure/errors.py
@@ -22,39 +22,14 @@
 # THE SOFTWARE.
 #
 
-import visa
+
+class Error(Exception):
+    pass
 
 
-def list_resources():
-    """
-    Prints the available resources, and returns a list of VISA resource names
-    
-    .. code-block:: python
+class RangeError(Error):
+    pass
 
-        resources = list_resources()
-        #prints (e.g.)
-            #0 : GPIB0::22::INSTR : Agilent Technologies,34410A,******
-            #1 : GPIB0::26::INSTR : Keithley Instruments Inc., Model 2612, *****
-        dmm = Agilent34410(resources[0])
-    
-    """
-    rm = visa.ResourceManager()
-    instrs = rm.list_resources()
-    for n, instr in enumerate(instrs):
-        # trying to catch errors in comunication
-        try:
-            res = rm.open_resource(instr)
-            # try to avoid errors from *idn?
-            try:
-                # noinspection PyUnresolvedReferences
-                idn = res.ask('*idn?')[:-1]
-            except visa.Error:
-                idn = "Not known"
-            finally:
-                res.close()
-                print(n, ":", instr, ":", idn)
-        except visa.VisaIOError as e:
-            print(n, ":", instr, ":", "Visa IO Error: check connections")
-            print(e)
-    rm.close()
-    return instrs
+
+# TODO should be deprecated someday
+RangeException = RangeError

--- a/pymeasure/experiment/config.py
+++ b/pymeasure/experiment/config.py
@@ -21,16 +21,41 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 import configparser
 import logging
-from .results import unique_filename
-import numpy as np
-import signal
-from pymeasure.log import setup_logging
 import os
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 
 def set_file(filename):
     os.environ['CONFIG'] = filename
+
 
 def get_config(filename='default_config.ini'):
     if 'CONFIG' in os.environ.keys():
@@ -39,6 +64,8 @@ def get_config(filename='default_config.ini'):
     config.read(filename)
     return config
 
+
+# noinspection PyProtectedMember
 def set_mpl_rcparams(config):
     if 'matplotlib.rcParams' in config._sections.keys():
         import matplotlib

--- a/pymeasure/experiment/experiment.py
+++ b/pymeasure/experiment/experiment.py
@@ -23,12 +23,13 @@
 #
 
 import logging
+
 log = logging.getLogger()
 log.addHandler(logging.NullHandler())
 
 try:
     from IPython import display
-except:
+except ImportError:
     log.warning("IPython could not be imported")
 
 from .results import unique_filename
@@ -42,19 +43,22 @@ import tempfile
 import gc
 
 
-
 def get_array(start, stop, step):
     """Returns a numpy array from start to stop"""
-    step = np.sign(stop-start)*abs(step)
-    return np.arange(start, stop+step, step)
+    step = np.sign(stop - start) * abs(step)
+    return np.arange(start, stop + step, step)
+
 
 def get_array_steps(start, stop, numsteps):
     """Returns a numpy array from start to stop in numsteps"""
-    return get_array(start, stop, (abs(stop-start)/numsteps))
+    return get_array(start, stop, (abs(stop - start) / numsteps))
+
 
 def get_array_zero(maxval, step):
     """Returns a numpy array from 0 to maxval to -maxval to 0"""
-    return np.concatenate((np.arange(0,maxval,step), np.arange(maxval, -maxval, -step), np.arange(-maxval, 0, step)))
+    return np.concatenate((np.arange(0, maxval, step), np.arange(maxval, -maxval, -step),
+                           np.arange(-maxval, 0, step)))
+
 
 def create_filename(title):
     """
@@ -63,7 +67,7 @@ def create_filename(title):
     """
     config = get_config()
     if 'Filename' in config._sections.keys():
-        filename = unique_filename(suffix='_%s' %title, **config._sections['Filename'])
+        filename = unique_filename(suffix='_%s' % title, **config._sections['Filename'])
     else:
         filename = tempfile.mktemp()
     return filename
@@ -97,6 +101,7 @@ class Experiment(object):
         experiment.data, as opposed to experiment.results.data for the 'raw' data.
     :param _data_timeout: Time limit for how long live plotting should wait for datapoints.
     """
+
     def __init__(self, title, procedure, analyse=(lambda x: x)):
         self.title = title
         self.procedure = procedure
@@ -139,10 +144,10 @@ class Experiment(object):
 
     def wait_for_data(self):
         """Wait for the data attribute to fill with datapoints."""
-        t=time.time()
+        t = time.time()
         while self.data.empty:
             time.sleep(.1)
-            if (time.time()-t)>self._data_timeout:
+            if (time.time() - t) > self._data_timeout:
                 log.warning('Timeout, no data received for liveplot')
                 return False
         return True
@@ -152,7 +157,7 @@ class Experiment(object):
         (an) in-line matplotlib graph(s). Will create a new plot as specified by input
         arguments, or will update (an) existing plot(s)."""
         if self.wait_for_data():
-            if not(self.plots):
+            if not (self.plots):
                 self.plot(*args, **kwargs)
             while not self.worker.should_stop():
                 self.update_plot()
@@ -189,16 +194,16 @@ class Experiment(object):
             self.data
             for plot in self.plots:
                 ax = plot['ax']
-                if plot['type']=='plot':
-                    x,y = plot['args'][0], plot['args'][1]
+                if plot['type'] == 'plot':
+                    x, y = plot['args'][0], plot['args'][1]
                     if type(y) == str:
                         y = [y]
-                    for yname,line in zip(y,ax.lines):
+                    for yname, line in zip(y, ax.lines):
                         self.update_line(ax, line, x, yname)
-                if plot['type']=='pcolor':
-                    x,y,z = plot['x'], plot['y'], plot['z']
+                if plot['type'] == 'pcolor':
+                    x, y, z = plot['x'], plot['y'], plot['z']
                     update_pcolor(ax, x, y, z)
-            
+
             display.clear_output(wait=True)
             display.display(*self.figs)
             time.sleep(0.1)
@@ -206,14 +211,14 @@ class Experiment(object):
             display.clear_output(wait=True)
             display.display(*self.figs)
             self._user_interrupt = True
-    
+
     def pcolor(self, xname, yname, zname, *args, **kwargs):
         """Plot the results from the experiment.data pandas dataframe in a pcolor graph.
         Store the plots in a plots list attribute."""
         title = self.title
-        x,y,z = self._data[xname], self._data[yname], self._data[zname]
+        x, y, z = self._data[xname], self._data[yname], self._data[zname]
         shape = (len(y.unique()), len(x.unique()))
-        diff = shape[0]*shape[1] - len(z)
+        diff = shape[0] * shape[1] - len(z)
         Z = np.concatenate((z.values, np.zeros(diff))).reshape(shape)
         df = pd.DataFrame(Z, index=y.unique(), columns=x.unique())
         ax = sns.heatmap(df)
@@ -222,15 +227,17 @@ class Experiment(object):
         pl.ylabel(yname)
         ax.invert_yaxis()
         pl.plt.show()
-        self.plots.append({'type': 'pcolor', 'x':xname, 'y':yname, 'z':zname, 'args':args, 'kwargs':kwargs, 'ax':ax})
+        self.plots.append(
+            {'type': 'pcolor', 'x': xname, 'y': yname, 'z': zname, 'args': args, 'kwargs': kwargs,
+             'ax': ax})
         if ax.get_figure() not in self.figs:
             self.figs.append(ax.get_figure())
-    
+
     def update_pcolor(self, ax, xname, yname, zname):
         """Update a pcolor graph with new data."""
-        x,y,z = self._data[xname], self._data[yname], self._data[zname]
+        x, y, z = self._data[xname], self._data[yname], self._data[zname]
         shape = (len(y.unique()), len(x.unique()))
-        diff = shape[0]*shape[1] - len(z)
+        diff = shape[0] * shape[1] - len(z)
         Z = np.concatenate((z.values, np.zeros(diff))).reshape(shape)
         df = pd.DataFrame(Z, index=y.unique(), columns=x.unique())
         cbar_ax = ax.get_figure().axes[1]

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -79,10 +79,10 @@ class IntegerParameter(Parameter):
     """
 
     def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, **kwargs):
-        super(IntegerParameter, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.units = units
-        self.minimum = minimum
-        self.maximum = maximum
+        self.minimum = int(minimum)
+        self.maximum = int(maximum)
 
     @property
     def value(self):
@@ -160,7 +160,7 @@ class FloatParameter(Parameter):
     """
 
     def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, **kwargs):
-        super(FloatParameter, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.units = units
         self.minimum = minimum
         self.maximum = maximum
@@ -211,9 +211,10 @@ class VectorParameter(Parameter):
     :param default: The default value
     :param ui_class: A Qt class to use for the UI of this parameter
     """
+
     def __init__(self, name, length=3, units=None, **kwargs):
+        super().__init__(name, **kwargs)
         self._length = length
-        super(VectorParameter, self).__init__(name, **kwargs)
         self.units = units
 
     @property
@@ -273,8 +274,8 @@ class ListParameter(Parameter):
     """
 
     def __init__(self, name, choices=None, units=None, **kwargs):
+        super().__init__(name, **kwargs)
         self._choices = choices
-        super(ListParameter, self).__init__(name, **kwargs)
         self.units = units
 
     @property
@@ -292,6 +293,7 @@ class ListParameter(Parameter):
             raise ValueError("Invalid choice for parameter. "
                              "Must be one of %s" % str(self._choices))
 
+
 class PhysicalParameter(VectorParameter):
     """ :class: '.VectorParameter' sub-class of 2 dimentions to store a value
     and its uncertainty.
@@ -306,10 +308,10 @@ class PhysicalParameter(VectorParameter):
     """
 
     def __init__(self, name, uncertaintyType='absolute', **kwargs):
-        super(PhysicalParameter, self).__init__(name, length=2, **kwargs)
+        super().__init__(name, length=2, **kwargs)
         self._utype = ListParameter("uncertainty type",
-                                   choices = ['absolute', 'relative', 'percentage'],
-                                   default = None)
+                                    choices=['absolute', 'relative', 'percentage'],
+                                    default=None)
         self._utype.value = uncertaintyType
 
     @property
@@ -357,26 +359,26 @@ class PhysicalParameter(VectorParameter):
         if self.is_set():
             # Convert uncertainty value to the new type
             if (oldType, newType) == ('absolute', 'relative'):
-                self._value[1] = abs(self._value[1]/self._value[0])
+                self._value[1] = abs(self._value[1] / self._value[0])
             if (oldType, newType) == ('relative', 'absolute'):
-                self._value[1] = abs(self._value[1]*self._value[0])
+                self._value[1] = abs(self._value[1] * self._value[0])
             if (oldType, newType) == ('relative', 'percentage'):
-                self._value[1] = abs(self._value[1]*100.0)
+                self._value[1] = abs(self._value[1] * 100.0)
             if (oldType, newType) == ('percentage', 'relative'):
-                self._value[1] = abs(self._value[1]*0.01)
+                self._value[1] = abs(self._value[1] * 0.01)
             if (oldType, newType) == ('percentage', 'absolute'):
-                self._value[1] = abs(self._value[1]*self._value[0]*0.01)
+                self._value[1] = abs(self._value[1] * self._value[0] * 0.01)
             if (oldType, newType) == ('absolute', 'percentage'):
-                self._value[1] = abs(self._value[1]*100.0/self._value[0])
+                self._value[1] = abs(self._value[1] * 100.0 / self._value[0])
 
     def __str__(self):
         if not self.is_set():
             return ''
-        result = "%g +/- %g" %(self._value[0], self._value[1])
+        result = "%g +/- %g" % (self._value[0], self._value[1])
         if self.units:
-            result += " %s" %self.units
-        if self._utype.value != None:
-            result += " (%s)" %self._utype.value
+            result += " %s" % self.units
+        if self._utype.value is not None:
+            result += " (%s)" % self._utype.value
         return result
 
     def __repr__(self):
@@ -399,11 +401,12 @@ class Measurable(object):
     :param default: The default value
     """
     DATA_COLUMNS = []
+
     def __init__(self, name, fget=None, units=None, measure=True, default=None, **kwargs):
         self.name = name
         self.units = units
         self.measure = measure
-        if fget != None:
+        if fget is not None:
             self.fget = fget
             self._value = fget()
         else:

--- a/pymeasure/experiment/tests/test_listeners.py
+++ b/pymeasure/experiment/tests/test_listeners.py
@@ -22,11 +22,14 @@
 # THE SOFTWARE.
 #
 
+import time
+from multiprocessing import Queue
+
 from pymeasure.experiment.listeners import Listener, Recorder
 from pymeasure.experiment.results import Results
-from multiprocessing import Queue
-from time import sleep
 
+# TODO: Make results_for_testing.csv
+# TODO: Make procedure_for_testing.py
 
 """
 def test_recorder_stop():
@@ -35,6 +38,3 @@ def test_recorder_stop():
     r = Recorder(d, q)
     r.
 """
-
-# TODO: Make results_for_testing.csv
-# TODO: Make procedure_for_testing.py

--- a/pymeasure/experiment/tests/test_parameters.py
+++ b/pymeasure/experiment/tests/test_parameters.py
@@ -23,72 +23,80 @@
 #
 
 import pytest
-from pymeasure.experiment.parameters import (
-    Parameter, IntegerParameter, BooleanParameter, FloatParameter
-)
+
+from pymeasure.experiment.parameters import Parameter
+from pymeasure.experiment.parameters import IntegerParameter
+from pymeasure.experiment.parameters import BooleanParameter
+from pymeasure.experiment.parameters import FloatParameter
+
 
 def test_parameter_default():
     p = Parameter('Test', default=5)
     assert p.value == 5
 
+
 def test_integer_units():
     p = IntegerParameter('Test', units='V')
     assert p.units == 'V'
 
+
 def test_integer_value():
     p = IntegerParameter('Test')
     with pytest.raises(ValueError):
-        v = p.value # not set
+        v = p.value  # not set
     with pytest.raises(ValueError):
-        p.value = 'a' # not an integer
-    p.value = 0.5 # a float
+        p.value = 'a'  # not an integer
+    p.value = 0.5  # a float
     assert p.value == 0
-    p.value = False # a boolean
+    p.value = False  # a boolean
     assert p.value == 0
     p.value = 10
     assert p.value == 10
+
 
 def test_integer_bounds():
     p = IntegerParameter('Test', minimum=0, maximum=10)
     p.value = 10
     assert p.value == 10
     with pytest.raises(ValueError):
-        p.value = 100 # above maximum
+        p.value = 100  # above maximum
     with pytest.raises(ValueError):
-        p.value = -100 # below minimum
+        p.value = -100  # below minimum
+
 
 def test_boolean_value():
     p = BooleanParameter('Test')
     with pytest.raises(ValueError):
-        v = p.value # not set
-    p.value = 'a' # a string
+        v = p.value  # not set
+    p.value = 'a'  # a string
     assert p.value == True
-    p.value = 10 # a number
+    p.value = 10  # a number
     assert p.value == True
-    p.value = 0 # zero
+    p.value = 0  # zero
     assert p.value == False
     p.value = True
     assert p.value == True
 
+
 def test_float_value():
     p = FloatParameter('Test')
     with pytest.raises(ValueError):
-        v = p.value # not set
+        v = p.value  # not set
     with pytest.raises(ValueError):
-        p.value = 'a' # not a float
-    p.value = False # boolean
+        p.value = 'a'  # not a float
+    p.value = False  # boolean
     assert p.value == 0.0
     p.value = 100
     assert p.value == 100.0
+
 
 def test_float_bounds():
     p = FloatParameter('Test', minimum=0.1, maximum=0.5)
     p.value = 0.3
     assert p.value == 0.3
     with pytest.raises(ValueError):
-        p.value = 10 # above maximum
+        p.value = 10  # above maximum
     with pytest.raises(ValueError):
-        p.value = -10 # below minimum
-
+        p.value = -10  # below minimum
 
 # TODO: Add tests for VectorParameter, ListParamter, and Measurable

--- a/pymeasure/experiment/tests/test_procedure.py
+++ b/pymeasure/experiment/tests/test_procedure.py
@@ -23,6 +23,7 @@
 #
 
 import pytest
+
 from pymeasure.experiment.procedure import Procedure
 from pymeasure.experiment.parameters import Parameter
 
@@ -39,6 +40,5 @@ def test_parameters():
     objs = p.parameter_objects()
     assert 'x' in objs
     assert objs['x'].value == p.x
-
 
 # TODO: Add tests for measureables

--- a/pymeasure/experiment/tests/test_results.py
+++ b/pymeasure/experiment/tests/test_results.py
@@ -23,9 +23,8 @@
 #
 
 import pytest
-from pymeasure.experiment.results import Results
+
 import os
-import tempfile
 from importlib.machinery import SourceFileLoader
 
 # Load the procedure, without it being in a module
@@ -39,6 +38,3 @@ def test_procedure():
     p = procedure.TestProcedure()
     assert p.iterations == 100
     assert hasattr(p, 'execute')
-
-
-

--- a/pymeasure/experiment/tests/test_workers.py
+++ b/pymeasure/experiment/tests/test_workers.py
@@ -23,12 +23,13 @@
 #
 
 import pytest
-from pymeasure.experiment.workers import Worker
-from pymeasure.experiment.results import Results
 import os
 import tempfile
 from time import sleep
 from importlib.machinery import SourceFileLoader
+
+from pymeasure.experiment.workers import Worker
+from pymeasure.experiment.results import Results
 
 # Load the procedure, without it being in a module
 data_path = os.path.join(os.path.dirname(__file__), 'data/procedure_for_testing.py')
@@ -47,6 +48,7 @@ def test_procedure():
     assert p.iterations == 100
     assert hasattr(p, 'execute')
 
+
 def test_worker_stop():
     p = procedure.TestProcedure()
     f = tempfile.mktemp()
@@ -57,6 +59,7 @@ def test_worker_stop():
     assert w.should_stop()
     w.join()
 
+
 @slow
 def test_worker_finish():
     p = procedure.TestProcedure()
@@ -66,4 +69,4 @@ def test_worker_finish():
     w.start()
     w.join()
     sleep(2)
-    assert w.is_alive() == False
+    assert not w.is_alive()

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -22,22 +22,11 @@
 # THE SOFTWARE.
 #
 
+from ..errors import RangeError, RangeException
 from .instrument import Instrument
 from .mock import Mock
 from .resources import list_resources
-
-def discreteTruncate(number, discreteSet):
-    """ Truncates the number to the closest element in the positive discrete set.
-    Returns False if the number is larger than the maximum value or negative.    
-    """
-    if number < 0: return False
-    discreteSet.sort()
-    for item in discreteSet:
-        if number <= item: return item
-    return False
-    
-
-class RangeException(Exception): pass
+from .validators import discreteTruncate
 
 from . import agilent
 from . import anritsu
@@ -52,4 +41,3 @@ from . import srs
 from . import tektronix
 from . import thorlabs
 from . import yokogawa
-

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -23,14 +23,14 @@
 #
 
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-from pymeasure.adapters.visa import VISAAdapter
-from pymeasure.adapters import FakeAdapter
 
 import numpy as np
-import inspect
+
+from pymeasure.adapters import FakeAdapter
+from pymeasure.adapters.visa import VISAAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class Instrument(object):
@@ -43,6 +43,8 @@ class Instrument(object):
     :param name: A string name
     :param includeSCPI: A boolean, which toggles the inclusion of standard SCPI commands
     """
+
+    # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
             if isinstance(adapter, (int, str)):
@@ -54,21 +56,23 @@ class Instrument(object):
         self.name = name
         self.SCPI = includeSCPI
         self.adapter = adapter
+
         class Object(object):
             pass
+
         self.get = Object()
 
         # TODO: Determine case basis for the addition of these methods
         if includeSCPI:
             # Basic SCPI commands
-            self.status = self.measurement("*STB?", 
-                """ Returns the status of the instrument """)
+            self.status = self.measurement("*STB?",
+                                           """ Returns the status of the instrument """)
             self.complete = self.measurement("*OPC?",
-                """ TODO: Add this doc """)
+                                             """ TODO: Add this doc """)
 
         self.isShutdown = False
         log.info("Initializing %s." % self.name)
-        
+
     @property
     def id(self):
         """ Requests and returns the identification of the instrument. """
@@ -76,7 +80,7 @@ class Instrument(object):
             return self.adapter.ask("*IDN?").strip()
         else:
             return "Warning: Property not implemented."
-            
+
     # Wrapper functions for the Adapter object
     def ask(self, command):
         """ Writes the command to the instrument through the adapter
@@ -93,7 +97,7 @@ class Instrument(object):
         """
         self.adapter.write(command)
 
-    def read(self): 
+    def read(self):
         """ Reads from the instrument through the adapter and returns the
         response.
         """
@@ -110,7 +114,7 @@ class Instrument(object):
 
     @staticmethod
     def control(get_command, set_command, docs,
-                validator=lambda v, vs: v, values=[], map_values=False,
+                validator=lambda v, vs: v, values=(), map_values=False,
                 get_process=lambda v: v, set_process=lambda v: v,
                 check_set_errors=False, check_get_errors=False,
                 **kwargs):
@@ -123,7 +127,7 @@ class Instrument(object):
         :param docs: A docstring that will be included in the documentation
         :param validator: A function that takes both a value and a group of valid values
                           and returns a valid value, while it otherwise raises an exception
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
@@ -135,7 +139,7 @@ class Instrument(object):
         :param check_get_errors: Toggles checking errors after getting        
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -147,9 +151,9 @@ class Instrument(object):
                 value = get_process(vals[0])
                 if not map_values:
                     return value
-                elif type(values) in (list, range):
+                elif isinstance(values, (list, tuple, range)):
                     return values[int(value)]
-                elif type(values) is dict:
+                elif isinstance(values, dict):
                     return inverse[value]
                 else:
                     raise ValueError(
@@ -164,9 +168,9 @@ class Instrument(object):
             value = set_process(validator(value, values))
             if not map_values:
                 pass
-            elif type(values) in (list, range):
+            elif isinstance(values, (list, tuple, range)):
                 value = values.index(value)
-            elif type(values) is dict:
+            elif isinstance(values, dict):
                 value = values[value]
             else:
                 raise ValueError(
@@ -181,18 +185,18 @@ class Instrument(object):
         fget.__doc__ = docs
 
         return property(fget, fset)
-    
+
     @staticmethod
-    def measurement(get_command, docs, values=[], map_values=None,
-                get_process=lambda v: v, command_process=lambda c: c, 
-                check_get_errors=False, **kwargs):
+    def measurement(get_command, docs, values=(), map_values=None,
+                    get_process=lambda v: v, command_process=lambda c: c,
+                    check_get_errors=False, **kwargs):
         """ Returns a property for the class based on the supplied
         commands. This is a measurement quantity that may only be 
         read from the instrument, not set.
 
         :param get_command: A string command that asks for the value
         :param docs: A docstring that will be included in the documentation
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
@@ -203,7 +207,7 @@ class Instrument(object):
         :param check_get_errors: Toggles checking errors after getting 
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -215,9 +219,9 @@ class Instrument(object):
                 value = get_process(vals[0])
                 if not map_values:
                     return value
-                elif type(values) in (list, range):
+                elif isinstance(values, (list, tuple, range)):
                     return values[int(value)]
-                elif type(values) is dict:
+                elif isinstance(values, dict):
                     return inverse[value]
                 else:
                     raise ValueError(
@@ -234,7 +238,7 @@ class Instrument(object):
 
     @staticmethod
     def setting(set_command, docs,
-                validator=lambda x, y: x, values=[], map_values=False,
+                validator=lambda x, y: x, values=(), map_values=False,
                 check_set_errors=False,
                 **kwargs):
         """Returns a property for the class based on the supplied
@@ -245,14 +249,14 @@ class Instrument(object):
         :param docs: A docstring that will be included in the documentation
         :param validator: A function that takes both a value and a group of valid values
                           and returns a valid value, while it otherwise raises an exception
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
         :param check_set_errors: Toggles checking errors after setting     
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -263,9 +267,9 @@ class Instrument(object):
             value = validator(value, values)
             if not map_values:
                 pass
-            elif type(values) in (list, range):
+            elif isinstance(values, (list, tuple, range)):
                 value = values.index(value)
-            elif type(values) is dict:
+            elif isinstance(values, dict):
                 value = values[value]
             else:
                 raise ValueError(
@@ -280,7 +284,6 @@ class Instrument(object):
         fget.__doc__ = docs
 
         return property(fget, fset)
-
 
     # TODO: Determine case basis for the addition of this method
     def clear(self):
@@ -310,7 +313,7 @@ class FakeInstrument(Instrument):
     """
 
     def __init__(self, **kwargs):
-        super(FakeInstrument, self).__init__(
+        super().__init__(
             FakeAdapter(),
             "Fake Instrument",
             includeSCPI=False,

--- a/pymeasure/instruments/mock.py
+++ b/pymeasure/instruments/mock.py
@@ -22,17 +22,21 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument
+import numpy
+import time
+
 from pymeasure.adapters import FakeAdapter
-import numpy, time
+from pymeasure.instruments import Instrument
+
 
 class Mock(Instrument):
-    '''Mock instrument for testing.'''
+    """Mock instrument for testing."""
+
     def __init__(self, wait=.1, **kwargs):
-        super(Mock, self).__init__(
+        super().__init__(
             FakeAdapter,
             "Mock instrument",
-            includeSCPI = False,
+            includeSCPI=False,
             **kwargs
         )
         self._wait = wait
@@ -42,58 +46,57 @@ class Mock(Instrument):
         self._time = 0
         self._wave = self.wave
         self._units = {'voltage': 'V',
-                      'output_voltage': 'V',
-                      'time': 's',
-                      'wave': 'a.u.'}
+                       'output_voltage': 'V',
+                       'time': 's',
+                       'wave': 'a.u.'}
 
     def get_time(self):
         """Get elapsed time"""
-        if self._tstart==0:
+        if self._tstart == 0:
             self._tstart = time.time()
-        self._time = time.time()-self._tstart
+        self._time = time.time() - self._tstart
         return self._time
-    
+
     def set_time(self, value):
         """
         Wait for the timer to reach the specified time.
         If value = 0, reset.
         """
-        if value==0:
+        if value == 0:
             self._tstart = 0
         else:
             while self.time < value:
                 time.sleep(0.001)
-        return True
 
     def reset_time(self):
-        '''Reset the timer to 0 s.'''
+        """Reset the timer to 0 s."""
         self.time = 0
-        self.time
+        self.get_time()
 
-    time = property(fget = get_time, fset = set_time)
+    time = property(fget=get_time, fset=set_time)
 
     def get_wave(self):
         """Get wave."""
         return float(numpy.sin(self.time))
 
-    wave = property(fget = get_wave)
+    wave = property(fget=get_wave)
 
     def get_voltage(self):
         """Get the voltage."""
         time.sleep(self._wait)
         return self._voltage
-    
-        def __getitem__(self, keys):
-            return keys
 
-    voltage = property(fget = get_voltage)
-    
+    def __getitem__(self, keys):
+        return keys
+
+    voltage = property(fget=get_voltage)
+
     def get_output_voltage(self):
         return self._output_voltage
-    
+
     def set_output_voltage(self, value):
         """Set the voltage."""
         time.sleep(self._wait)
         self._output_voltage = value
 
-    output_voltage = property(fget = get_output_voltage, fset = set_output_voltage)
+    output_voltage = property(fget=get_output_voltage, fset=set_output_voltage)

--- a/pymeasure/instruments/tests/test_instrument.py
+++ b/pymeasure/instruments/tests/test_instrument.py
@@ -26,16 +26,16 @@ import pytest
 from pymeasure.instruments.instrument import Instrument, FakeInstrument
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
-def test_fake_instrument():
 
+def test_fake_instrument():
     fake = FakeInstrument()
     fake.write("Testing")
     assert fake.read() == "Testing"
     assert fake.read() == ""
     assert fake.values("5") == [5]
 
-def test_control_doc():
 
+def test_control_doc():
     doc = """ X property """
 
     class Fake(Instrument):
@@ -45,15 +45,15 @@ def test_control_doc():
 
     assert Fake.x.__doc__ == doc
 
+
 def test_control_validator():
-
     class Fake(FakeInstrument):
-
         x = Instrument.control(
-            "", "%d", "", 
+            "", "%d", "",
             validator=strict_discrete_set,
             values=range(10),
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '5'
@@ -64,15 +64,14 @@ def test_control_validator():
 
 
 def test_control_validator_map():
-
     class Fake(FakeInstrument):
-
         x = Instrument.control(
-            "", "%d", "", 
+            "", "%d", "",
             validator=strict_discrete_set,
             values=[4, 5, 6, 7],
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '1'
@@ -83,14 +82,14 @@ def test_control_validator_map():
 
 
 def test_control_dict_map():
-
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_discrete_set,
-            values={5:1, 10:2, 20:3},
+            values={5: 1, 10: 2, 20: 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '1'
@@ -99,15 +98,16 @@ def test_control_dict_map():
     fake.x = 20
     assert fake.read() == '3'
 
-def test_control_dict_str_map():
 
+def test_control_dict_str_map():
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_discrete_set,
-            values={'X':1, 'Y':2, 'Z':3},
+            values={'X': 1, 'Y': 2, 'Z': 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 'X'
     assert fake.read() == '1'
@@ -116,15 +116,15 @@ def test_control_dict_str_map():
     fake.x = 'Z'
     assert fake.read() == '3'
 
+
 def test_control_process():
-    
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_range,
             values=[5e-3, 120e-3],
-            get_process=lambda v: v*1e-3,
-            set_process=lambda v: v*1e3,
+            get_process=lambda v: v * 1e-3,
+            set_process=lambda v: v * 1e3,
         )
 
     fake = Fake()
@@ -133,8 +133,8 @@ def test_control_process():
     fake.x = 30e-3
     assert fake.x == 30e-3
 
+
 def test_control_get_process():
-    
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "JUNK%d", "",
@@ -149,13 +149,15 @@ def test_control_get_process():
     fake.x = 5
     assert fake.x == 5
 
+
 def test_measurement_dict_str_map():
     class Fake(FakeInstrument):
         x = Instrument.measurement(
             "", "",
-            values={'X':1, 'Y':2, 'Z':3},
+            values={'X': 1, 'Y': 2, 'Z': 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.write('1')
     assert fake.x == 'X'

--- a/pymeasure/instruments/tests/test_validators.py
+++ b/pymeasure/instruments/tests/test_validators.py
@@ -29,6 +29,7 @@ from pymeasure.instruments.validators import (
     joined_validators
 )
 
+
 def test_strict_range():
     assert strict_range(5, range(10)) == 5
     assert strict_range(5.1, range(10)) == 5.1
@@ -43,17 +44,20 @@ def test_strict_discrete_set():
     with pytest.raises(ValueError) as e_info:
         strict_discrete_set(20, range(10))
 
+
 def test_truncated_range():
     assert truncated_range(5, range(10)) == 5
     assert truncated_range(5.1, range(10)) == 5.1
     assert truncated_range(-10, range(10)) == 0
     assert truncated_range(20, range(10)) == 9
 
+
 def test_truncated_discrete_set():
     assert truncated_discrete_set(5, range(10)) == 5
     assert truncated_discrete_set(5.1, range(10)) == 6
     assert truncated_discrete_set(11, range(10)) == 9
     assert truncated_discrete_set(-10, range(10)) == 0
+
 
 def test_joined_validators():
     tst_validator = joined_validators(strict_discrete_set, strict_range)

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -32,12 +32,13 @@ def strict_range(value, values):
     :param values: A range of values (range, list, etc.)
     :raises: ValueError if the value is out of the range
     """
-    if value <= max(values) and value >= min(values):
+    if min(values) <= value <= max(values):
         return value
     else:
         raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
             value, min(values), max(values)
         ))
+
 
 def strict_discrete_set(value, values):
     """ Provides a validator function that returns the value
@@ -54,6 +55,7 @@ def strict_discrete_set(value, values):
             value, values
         ))
 
+
 def truncated_range(value, values):
     """ Provides a validator function that returns the value
     if it is in the range. Otherwise it returns the closest
@@ -62,12 +64,13 @@ def truncated_range(value, values):
     :param value: A value to test
     :param values: A set of values that are valid
     """
-    if value <= max(values) and value >= min(values):
+    if min(values) <= value <= max(values):
         return value
     elif value > max(values):
         return max(values)
     else:
         return min(values)
+
 
 def truncated_discrete_set(value, values):
     """ Provides a validator function that returns the value
@@ -83,13 +86,16 @@ def truncated_discrete_set(value, values):
     for v in values:
         if value <= v:
             return v
-    return v
+
+    return values[-1]
+
 
 def joined_validators(*validators):
     """ Join a list of validators together as a single.  Expects a list of validator functions and values.
 
     :param validators: an iterable of other validators
     """
+
     def validate(value, values):
         for validator, vals in zip(validators, values):
             try:
@@ -97,4 +103,18 @@ def joined_validators(*validators):
             except (ValueError, TypeError):
                 pass
         raise ValueError("Value of {} not in chained validator set".format(value))
+
     return validate
+
+
+def discreteTruncate(number, discreteSet):
+    """ Truncates the number to the closest element in the positive discrete set.
+    Returns False if the number is larger than the maximum value or negative.
+    """
+    if number < 0:
+        return False
+    discreteSet.sort()
+    for item in discreteSet:
+        if number <= item:
+            return item
+    return False

--- a/pymeasure/process.py
+++ b/pymeasure/process.py
@@ -22,10 +22,15 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from multiprocessing import set_start_method, Process, Event
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 # Force Windows multiprocessing behavior on Unix
-set_start_method('spawn', force=True)
+set_start_method('spawn')
 
 
 class StoppableProcess(Process):
@@ -34,9 +39,9 @@ class StoppableProcess(Process):
     """
 
     def __init__(self):
+        super().__init__()
         self._should_stop = Event()
         self._should_stop.clear()
-        super(StoppableProcess, self).__init__()
 
     def join(self, timeout=0):
         """ Joins the current process and forces it to stop after
@@ -47,7 +52,7 @@ class StoppableProcess(Process):
         self._should_stop.wait(timeout)
         if not self.should_stop():
             self.stop()
-        super(StoppableProcess, self).join(0)
+        super().join(0)
 
     def stop(self):
         self._should_stop.set()
@@ -58,4 +63,3 @@ class StoppableProcess(Process):
     def __repr__(self):
         return "<%s(should_stop=%s)>" % (
             self.__class__.__name__, self.should_stop())
-

--- a/pymeasure/tests/test_log.py
+++ b/pymeasure/tests/test_log.py
@@ -22,27 +22,28 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.log import Scribe
+import time
 from multiprocessing import Queue
-from time import sleep
 
+from pymeasure.log import Scribe
+
+
+# TODO: Add tests for logging convenience functions and TopicQueueHandler
 
 def test_scribe_stop():
     q = Queue()
     s = Scribe(q)
     s.start()
-    assert s.is_alive() == True
+    assert s.is_alive() is True
     s.stop()
-    assert s.is_alive() == False
+    assert s.is_alive() is False
+
 
 def test_scribe_finish():
     q = Queue()
     s = Scribe(q)
     s.start()
-    assert s.is_alive() == True
+    assert s.is_alive() is True
     q.put(None)
-    sleep(0.1)
-    assert s.is_alive() == False
-
-
-# TODO: Add tests for logging convenience functions and TopicQueueHandler
+    time.sleep(0.1)
+    assert s.is_alive() is False

--- a/pymeasure/tests/test_process.py
+++ b/pymeasure/tests/test_process.py
@@ -29,11 +29,12 @@ def test_stopping():
     p = StoppableProcess()
     p.start()
     p.stop()
-    assert p.should_stop() == True
+    assert p.should_stop() is True
     p.join()
+
 
 def test_joining():
     p = StoppableProcess()
     p.start()
     p.join()
-    assert p.should_stop() == True
+    assert p.should_stop() is True

--- a/pymeasure/tests/test_thread.py
+++ b/pymeasure/tests/test_thread.py
@@ -29,11 +29,12 @@ def test_stopping():
     t = StoppableThread()
     t.start()
     t.stop()
-    assert t.should_stop() == True
+    assert t.should_stop() is True
     t.join()
+
 
 def test_joining():
     t = StoppableThread()
     t.start()
     t.join()
-    assert t.should_stop() == True
+    assert t.should_stop() is True

--- a/pymeasure/thread.py
+++ b/pymeasure/thread.py
@@ -22,7 +22,12 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from threading import Thread, Event
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class StoppableThread(Thread):
@@ -31,9 +36,9 @@ class StoppableThread(Thread):
     """
 
     def __init__(self):
+        super().__init__()
         self._should_stop = Event()
         self._should_stop.clear()
-        super(StoppableThread, self).__init__()
 
     def join(self, timeout=0):
         """ Joins the current thread and forces it to stop after
@@ -44,7 +49,7 @@ class StoppableThread(Thread):
         self._should_stop.wait(timeout)
         if not self.should_stop():
             self.stop()
-        super(StoppableThread, self).join()
+        super().join()
 
     def stop(self):
         self._should_stop.set()

--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -1,0 +1,19 @@
+name: pymeasure
+dependencies:
+- numpy=1.12.1=py36_0
+- pandas=0.19.2=np112py36_1
+- pip=9.0.1=py36_1
+- py=1.4.34=py36_0
+- pyqt=5.6.0=py36_2
+- pyqtgraph=0.10.0=py36_0
+- pyserial=2.7=py36_0
+- pytest=3.1.1=py36_0
+- python=3.6.1=2
+- python-dateutil=2.6.0=py36_0
+- pytz=2017.2=py36_0
+- setuptools>=27.2.0
+- sip=4.18=py36_0
+- six=1.10.0=py36_0
+- wheel=0.29.0=py36_0
+- pip:
+  - pyvisa==1.8

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -5,5 +5,5 @@ pytest==2.9.1
 python-dateutil==2.5.2
 pytz==2016.3
 six==1.10.0
-PyVISA==1.8
+pyvisa==1.8
 pyserial==2.7

--- a/setup.py
+++ b/setup.py
@@ -32,16 +32,26 @@ setup(
     packages=find_packages(),
     scripts=[],
     url='https://github.com/ralph-group/pymeasure',
-    download_url = 'https://github.com/ralph-group/pymeasure/tarball/v0.4.4',
+    download_url='https://github.com/ralph-group/pymeasure/tarball/v0.4.4',
     license='MIT License',
     description='Scientific measurement library for instruments, experiments, and live-plotting',
     long_description=open('README.rst').read() + "\n\n" + open('CHANGES.txt').read(),
     install_requires=[
-        "Numpy >= 1.6.1",
+        "numpy >= 1.6.1",
         "pandas >= 0.14",
         "pyvisa >= 1.8",
         "pyserial >= 2.7",
         "pyqtgraph >= 0.9.10"
+    ],
+    extras_require={
+        'matplotlib': ['matplotlib >= 2.0.2'],
+        'tcp': [
+            'zmq >= 16.0.2',
+            'cloudpickle >= 0.3.1'
+        ]
+    },
+    tests_require=[
+        'pytest >= 2.9.1'
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## General Fixes
1. Create new file with base errors.
2. Make sure imports are always at the top of the file, before any other code (also clears IDE from yellow warnings).
3. Fix pep8 compatibility (spaces, blank lines, indentations).
4. Replace mutable default values (`values=[]`) with immutable alternative (`values=()`).
6. Replace `super(...)` with the new `super()`. (see: https://github.com/ralph-group/pymeasure/pull/87#issuecomment-311655493)
7. Replace three single-quotes with three double-quotes for documentation (for consistency, and also to clear yellow warnings in IDE).
8. Replace blank `except:` statements with `except Exception:` or with more specific exceptions.
9. Replace `b <= c and b >= a` kind of conditions with `a <= b <= c`.
10. Prefer relative import for modules from the same package.
11. Fix `!= None` to `is not None`. Same for `True`, `False`.
12. Use `isinstance(...)` instead of `type(...) is ...`.
13. Remove the `force-True` argument from `set_start_method('spawn')` in pymeasure/process.py. It doesn't seem to be such an argument.

## pymeasure.adapters
1. Change the way `PrologixAdapter` and 'SerialAdapter' handle `serial.Serial` object as its adapter.
2. Inherit `__del__` from `SerialAdapter` to `PrologixAdapter` instead of rewriting it.

## pymeasure.experiments
1. Support recording results to multiple files.
3. Change `Recorder` to inherit from `logging.handlers.QueueListener` that does about the same thing. Same thing for `Scribe`. Actually, it doesn't inherit directly from `logging.handlers.QueueListener` but from `pymeasure.log.QueueListener` that includes the additional `is_alive()` method.
4. Add to `pymeasure.experiment.listeners` a class called `Monitor`, which is like `Recorder` but for console logging.
5. Rename the `data`  to `record` in `Worker.emit()` arguments, for consistency with the other modules (where it's called `record`).
6. Modify the way `Worker` handle exceptions and aborts:
   - Use specific methods `handle_exception()`, `handle_abort()`.
   - Log the event using `log.exception()` that saves the traceback automatically.
   - Handle failure in `startup()` like failure in `execute()`. The motivation for this is that `startup()` may turn on some instruments that need to be shutdown safely if the procedure fails (even if it fails in the `startup()` phase). The alternative would be to include the startup phase in the `execute()` method. However, I thought it'd be better to separate startup from execute.
7. Add `**kwargs` to `file_log()`. It's useful when you wish to use different mode (i.e. `a` instead of `w`) in the log file.
8. Use the `prepare()` method in `TopicQueueHandler` to prepare the record. This method was made exactly for this use.

## pymeasure.display
1. It's seems that `QtCore.QObject._continuous` was renamed to `QtCore.QObject._is_continuous`, so I also changed it in the relevant code.
2. Add `matplotlib` as an optional requirement.

## TCP
1. Use `cloudpickle` for serialization. It make the serialization process more straight-forward.
2. Add `zmq`, `cloudpickle` as optional requirements.

## Package and Requirements
1. Add Python3.6 to CI, and add conda-3.6.yml.
2. Add `matplotlib` and `zmq, cloudpickle` as extra requirements in the setup file (`extra_require`). TO install it with `matplotlib`, use `pip install pymeasure[matplotlib]`. To install it with TCP-support, use `pip install pymeasure[tcp]`. To do both, `pip install pymeasure[tcp,matplotlib]`.