### PR TITLE
Fix issues in pymeasure.instruments

### DIFF
--- a/pymeasure/errors.py
+++ b/pymeasure/errors.py
@@ -22,39 +22,14 @@
 # THE SOFTWARE.
 #
 
-import visa
+
+class Error(Exception):
+    pass
 
 
-def list_resources():
-    """
-    Prints the available resources, and returns a list of VISA resource names
-    
-    .. code-block:: python
+class RangeError(Error):
+    pass
 
-        resources = list_resources()
-        #prints (e.g.)
-            #0 : GPIB0::22::INSTR : Agilent Technologies,34410A,******
-            #1 : GPIB0::26::INSTR : Keithley Instruments Inc., Model 2612, *****
-        dmm = Agilent34410(resources[0])
-    
-    """
-    rm = visa.ResourceManager()
-    instrs = rm.list_resources()
-    for n, instr in enumerate(instrs):
-        # trying to catch errors in comunication
-        try:
-            res = rm.open_resource(instr)
-            # try to avoid errors from *idn?
-            try:
-                # noinspection PyUnresolvedReferences
-                idn = res.ask('*idn?')[:-1]
-            except visa.Error:
-                idn = "Not known"
-            finally:
-                res.close()
-                print(n, ":", instr, ":", idn)
-        except visa.VisaIOError as e:
-            print(n, ":", instr, ":", "Visa IO Error: check connections")
-            print(e)
-    rm.close()
-    return instrs
+
+# TODO should be deprecated someday
+RangeException = RangeError

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -22,22 +22,11 @@
 # THE SOFTWARE.
 #
 
+from ..errors import RangeError, RangeException
 from .instrument import Instrument
 from .mock import Mock
 from .resources import list_resources
-
-def discreteTruncate(number, discreteSet):
-    """ Truncates the number to the closest element in the positive discrete set.
-    Returns False if the number is larger than the maximum value or negative.    
-    """
-    if number < 0: return False
-    discreteSet.sort()
-    for item in discreteSet:
-        if number <= item: return item
-    return False
-    
-
-class RangeException(Exception): pass
+from .validators import discreteTruncate
 
 from . import agilent
 from . import anritsu
@@ -52,4 +41,3 @@ from . import srs
 from . import tektronix
 from . import thorlabs
 from . import yokogawa
-

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -23,14 +23,14 @@
 #
 
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-from pymeasure.adapters.visa import VISAAdapter
-from pymeasure.adapters import FakeAdapter
 
 import numpy as np
-import inspect
+
+from pymeasure.adapters import FakeAdapter
+from pymeasure.adapters.visa import VISAAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class Instrument(object):
@@ -43,6 +43,8 @@ class Instrument(object):
     :param name: A string name
     :param includeSCPI: A boolean, which toggles the inclusion of standard SCPI commands
     """
+
+    # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
             if isinstance(adapter, (int, str)):
@@ -54,21 +56,23 @@ class Instrument(object):
         self.name = name
         self.SCPI = includeSCPI
         self.adapter = adapter
+
         class Object(object):
             pass
+
         self.get = Object()
 
         # TODO: Determine case basis for the addition of these methods
         if includeSCPI:
             # Basic SCPI commands
-            self.status = self.measurement("*STB?", 
-                """ Returns the status of the instrument """)
+            self.status = self.measurement("*STB?",
+                                           """ Returns the status of the instrument """)
             self.complete = self.measurement("*OPC?",
-                """ TODO: Add this doc """)
+                                             """ TODO: Add this doc """)
 
         self.isShutdown = False
         log.info("Initializing %s." % self.name)
-        
+
     @property
     def id(self):
         """ Requests and returns the identification of the instrument. """
@@ -76,7 +80,7 @@ class Instrument(object):
             return self.adapter.ask("*IDN?").strip()
         else:
             return "Warning: Property not implemented."
-            
+
     # Wrapper functions for the Adapter object
     def ask(self, command):
         """ Writes the command to the instrument through the adapter
@@ -93,7 +97,7 @@ class Instrument(object):
         """
         self.adapter.write(command)
 
-    def read(self): 
+    def read(self):
         """ Reads from the instrument through the adapter and returns the
         response.
         """
@@ -110,7 +114,7 @@ class Instrument(object):
 
     @staticmethod
     def control(get_command, set_command, docs,
-                validator=lambda v, vs: v, values=[], map_values=False,
+                validator=lambda v, vs: v, values=(), map_values=False,
                 get_process=lambda v: v, set_process=lambda v: v,
                 check_set_errors=False, check_get_errors=False,
                 **kwargs):
@@ -123,7 +127,7 @@ class Instrument(object):
         :param docs: A docstring that will be included in the documentation
         :param validator: A function that takes both a value and a group of valid values
                           and returns a valid value, while it otherwise raises an exception
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
@@ -135,7 +139,7 @@ class Instrument(object):
         :param check_get_errors: Toggles checking errors after getting        
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -147,9 +151,9 @@ class Instrument(object):
                 value = get_process(vals[0])
                 if not map_values:
                     return value
-                elif type(values) in (list, range):
+                elif isinstance(values, (list, tuple, range)):
                     return values[int(value)]
-                elif type(values) is dict:
+                elif isinstance(values, dict):
                     return inverse[value]
                 else:
                     raise ValueError(
@@ -164,9 +168,9 @@ class Instrument(object):
             value = set_process(validator(value, values))
             if not map_values:
                 pass
-            elif type(values) in (list, range):
+            elif isinstance(values, (list, tuple, range)):
                 value = values.index(value)
-            elif type(values) is dict:
+            elif isinstance(values, dict):
                 value = values[value]
             else:
                 raise ValueError(
@@ -181,18 +185,18 @@ class Instrument(object):
         fget.__doc__ = docs
 
         return property(fget, fset)
-    
+
     @staticmethod
-    def measurement(get_command, docs, values=[], map_values=None,
-                get_process=lambda v: v, command_process=lambda c: c, 
-                check_get_errors=False, **kwargs):
+    def measurement(get_command, docs, values=(), map_values=None,
+                    get_process=lambda v: v, command_process=lambda c: c,
+                    check_get_errors=False, **kwargs):
         """ Returns a property for the class based on the supplied
         commands. This is a measurement quantity that may only be 
         read from the instrument, not set.
 
         :param get_command: A string command that asks for the value
         :param docs: A docstring that will be included in the documentation
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
@@ -203,7 +207,7 @@ class Instrument(object):
         :param check_get_errors: Toggles checking errors after getting 
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -215,9 +219,9 @@ class Instrument(object):
                 value = get_process(vals[0])
                 if not map_values:
                     return value
-                elif type(values) in (list, range):
+                elif isinstance(values, (list, tuple, range)):
                     return values[int(value)]
-                elif type(values) is dict:
+                elif isinstance(values, dict):
                     return inverse[value]
                 else:
                     raise ValueError(
@@ -234,7 +238,7 @@ class Instrument(object):
 
     @staticmethod
     def setting(set_command, docs,
-                validator=lambda x, y: x, values=[], map_values=False,
+                validator=lambda x, y: x, values=(), map_values=False,
                 check_set_errors=False,
                 **kwargs):
         """Returns a property for the class based on the supplied
@@ -245,14 +249,14 @@ class Instrument(object):
         :param docs: A docstring that will be included in the documentation
         :param validator: A function that takes both a value and a group of valid values
                           and returns a valid value, while it otherwise raises an exception
-        :param values: A list, range, or dictionary of valid values, that can be used
+        :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
         :param map_values: A boolean flag that determines if the values should be 
                           interpreted as a map
         :param check_set_errors: Toggles checking errors after setting     
         """
 
-        if map_values and type(values) is dict:
+        if map_values and isinstance(values, dict):
             # Prepare the inverse values for performance
             inverse = {v: k for k, v in values.items()}
 
@@ -263,9 +267,9 @@ class Instrument(object):
             value = validator(value, values)
             if not map_values:
                 pass
-            elif type(values) in (list, range):
+            elif isinstance(values, (list, tuple, range)):
                 value = values.index(value)
-            elif type(values) is dict:
+            elif isinstance(values, dict):
                 value = values[value]
             else:
                 raise ValueError(
@@ -280,7 +284,6 @@ class Instrument(object):
         fget.__doc__ = docs
 
         return property(fget, fset)
-
 
     # TODO: Determine case basis for the addition of this method
     def clear(self):
@@ -310,7 +313,7 @@ class FakeInstrument(Instrument):
     """
 
     def __init__(self, **kwargs):
-        super(FakeInstrument, self).__init__(
+        super().__init__(
             FakeAdapter(),
             "Fake Instrument",
             includeSCPI=False,

--- a/pymeasure/instruments/mock.py
+++ b/pymeasure/instruments/mock.py
@@ -22,17 +22,21 @@
 # THE SOFTWARE.
 #
 
-from pymeasure.instruments import Instrument
+import numpy
+import time
+
 from pymeasure.adapters import FakeAdapter
-import numpy, time
+from pymeasure.instruments import Instrument
+
 
 class Mock(Instrument):
-    '''Mock instrument for testing.'''
+    """Mock instrument for testing."""
+
     def __init__(self, wait=.1, **kwargs):
-        super(Mock, self).__init__(
+        super().__init__(
             FakeAdapter,
             "Mock instrument",
-            includeSCPI = False,
+            includeSCPI=False,
             **kwargs
         )
         self._wait = wait
@@ -42,58 +46,57 @@ class Mock(Instrument):
         self._time = 0
         self._wave = self.wave
         self._units = {'voltage': 'V',
-                      'output_voltage': 'V',
-                      'time': 's',
-                      'wave': 'a.u.'}
+                       'output_voltage': 'V',
+                       'time': 's',
+                       'wave': 'a.u.'}
 
     def get_time(self):
         """Get elapsed time"""
-        if self._tstart==0:
+        if self._tstart == 0:
             self._tstart = time.time()
-        self._time = time.time()-self._tstart
+        self._time = time.time() - self._tstart
         return self._time
-    
+
     def set_time(self, value):
         """
         Wait for the timer to reach the specified time.
         If value = 0, reset.
         """
-        if value==0:
+        if value == 0:
             self._tstart = 0
         else:
             while self.time < value:
                 time.sleep(0.001)
-        return True
 
     def reset_time(self):
-        '''Reset the timer to 0 s.'''
+        """Reset the timer to 0 s."""
         self.time = 0
-        self.time
+        self.get_time()
 
-    time = property(fget = get_time, fset = set_time)
+    time = property(fget=get_time, fset=set_time)
 
     def get_wave(self):
         """Get wave."""
         return float(numpy.sin(self.time))
 
-    wave = property(fget = get_wave)
+    wave = property(fget=get_wave)
 
     def get_voltage(self):
         """Get the voltage."""
         time.sleep(self._wait)
         return self._voltage
-    
-        def __getitem__(self, keys):
-            return keys
 
-    voltage = property(fget = get_voltage)
-    
+    def __getitem__(self, keys):
+        return keys
+
+    voltage = property(fget=get_voltage)
+
     def get_output_voltage(self):
         return self._output_voltage
-    
+
     def set_output_voltage(self, value):
         """Set the voltage."""
         time.sleep(self._wait)
         self._output_voltage = value
 
-    output_voltage = property(fget = get_output_voltage, fset = set_output_voltage)
+    output_voltage = property(fget=get_output_voltage, fset=set_output_voltage)

--- a/pymeasure/instruments/tests/test_instrument.py
+++ b/pymeasure/instruments/tests/test_instrument.py
@@ -26,16 +26,16 @@ import pytest
 from pymeasure.instruments.instrument import Instrument, FakeInstrument
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
 
-def test_fake_instrument():
 
+def test_fake_instrument():
     fake = FakeInstrument()
     fake.write("Testing")
     assert fake.read() == "Testing"
     assert fake.read() == ""
     assert fake.values("5") == [5]
 
-def test_control_doc():
 
+def test_control_doc():
     doc = """ X property """
 
     class Fake(Instrument):
@@ -45,15 +45,15 @@ def test_control_doc():
 
     assert Fake.x.__doc__ == doc
 
+
 def test_control_validator():
-
     class Fake(FakeInstrument):
-
         x = Instrument.control(
-            "", "%d", "", 
+            "", "%d", "",
             validator=strict_discrete_set,
             values=range(10),
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '5'
@@ -64,15 +64,14 @@ def test_control_validator():
 
 
 def test_control_validator_map():
-
     class Fake(FakeInstrument):
-
         x = Instrument.control(
-            "", "%d", "", 
+            "", "%d", "",
             validator=strict_discrete_set,
             values=[4, 5, 6, 7],
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '1'
@@ -83,14 +82,14 @@ def test_control_validator_map():
 
 
 def test_control_dict_map():
-
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_discrete_set,
-            values={5:1, 10:2, 20:3},
+            values={5: 1, 10: 2, 20: 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 5
     assert fake.read() == '1'
@@ -99,15 +98,16 @@ def test_control_dict_map():
     fake.x = 20
     assert fake.read() == '3'
 
-def test_control_dict_str_map():
 
+def test_control_dict_str_map():
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_discrete_set,
-            values={'X':1, 'Y':2, 'Z':3},
+            values={'X': 1, 'Y': 2, 'Z': 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.x = 'X'
     assert fake.read() == '1'
@@ -116,15 +116,15 @@ def test_control_dict_str_map():
     fake.x = 'Z'
     assert fake.read() == '3'
 
+
 def test_control_process():
-    
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "%d", "",
             validator=strict_range,
             values=[5e-3, 120e-3],
-            get_process=lambda v: v*1e-3,
-            set_process=lambda v: v*1e3,
+            get_process=lambda v: v * 1e-3,
+            set_process=lambda v: v * 1e3,
         )
 
     fake = Fake()
@@ -133,8 +133,8 @@ def test_control_process():
     fake.x = 30e-3
     assert fake.x == 30e-3
 
+
 def test_control_get_process():
-    
     class Fake(FakeInstrument):
         x = Instrument.control(
             "", "JUNK%d", "",
@@ -149,13 +149,15 @@ def test_control_get_process():
     fake.x = 5
     assert fake.x == 5
 
+
 def test_measurement_dict_str_map():
     class Fake(FakeInstrument):
         x = Instrument.measurement(
             "", "",
-            values={'X':1, 'Y':2, 'Z':3},
+            values={'X': 1, 'Y': 2, 'Z': 3},
             map_values=True,
         )
+
     fake = Fake()
     fake.write('1')
     assert fake.x == 'X'

--- a/pymeasure/instruments/tests/test_validators.py
+++ b/pymeasure/instruments/tests/test_validators.py
@@ -29,6 +29,7 @@ from pymeasure.instruments.validators import (
     joined_validators
 )
 
+
 def test_strict_range():
     assert strict_range(5, range(10)) == 5
     assert strict_range(5.1, range(10)) == 5.1
@@ -43,17 +44,20 @@ def test_strict_discrete_set():
     with pytest.raises(ValueError) as e_info:
         strict_discrete_set(20, range(10))
 
+
 def test_truncated_range():
     assert truncated_range(5, range(10)) == 5
     assert truncated_range(5.1, range(10)) == 5.1
     assert truncated_range(-10, range(10)) == 0
     assert truncated_range(20, range(10)) == 9
 
+
 def test_truncated_discrete_set():
     assert truncated_discrete_set(5, range(10)) == 5
     assert truncated_discrete_set(5.1, range(10)) == 6
     assert truncated_discrete_set(11, range(10)) == 9
     assert truncated_discrete_set(-10, range(10)) == 0
+
 
 def test_joined_validators():
     tst_validator = joined_validators(strict_discrete_set, strict_range)

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -32,12 +32,13 @@ def strict_range(value, values):
     :param values: A range of values (range, list, etc.)
     :raises: ValueError if the value is out of the range
     """
-    if value <= max(values) and value >= min(values):
+    if min(values) <= value <= max(values):
         return value
     else:
         raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
             value, min(values), max(values)
         ))
+
 
 def strict_discrete_set(value, values):
     """ Provides a validator function that returns the value
@@ -54,6 +55,7 @@ def strict_discrete_set(value, values):
             value, values
         ))
 
+
 def truncated_range(value, values):
     """ Provides a validator function that returns the value
     if it is in the range. Otherwise it returns the closest
@@ -62,12 +64,13 @@ def truncated_range(value, values):
     :param value: A value to test
     :param values: A set of values that are valid
     """
-    if value <= max(values) and value >= min(values):
+    if min(values) <= value <= max(values):
         return value
     elif value > max(values):
         return max(values)
     else:
         return min(values)
+
 
 def truncated_discrete_set(value, values):
     """ Provides a validator function that returns the value
@@ -83,13 +86,16 @@ def truncated_discrete_set(value, values):
     for v in values:
         if value <= v:
             return v
-    return v
+
+    return values[-1]
+
 
 def joined_validators(*validators):
     """ Join a list of validators together as a single.  Expects a list of validator functions and values.
 
     :param validators: an iterable of other validators
     """
+
     def validate(value, values):
         for validator, vals in zip(validators, values):
             try:
@@ -97,4 +103,18 @@ def joined_validators(*validators):
             except (ValueError, TypeError):
                 pass
         raise ValueError("Value of {} not in chained validator set".format(value))
+
     return validate
+
+
+def discreteTruncate(number, discreteSet):
+    """ Truncates the number to the closest element in the positive discrete set.
+    Returns False if the number is larger than the maximum value or negative.
+    """
+    if number < 0:
+        return False
+    discreteSet.sort()
+    for item in discreteSet:
+        if number <= item:
+            return item
+    return False


### PR DESCRIPTION
1. Create new file with base errors.
2. Make sure imports are always at the top of the file, before any other code (also clears IDE from yellow warnings).
3. Fix pep8 compatibility (spaces, blank lines, indentations).
4. Replace mutable default values (`values=[]`) with immutable alternative (`values=()`).
5. Replace `type(<var>) is <type>` with `isinstance(<var>, <type>)`.
6. Replace `super(...)` with the new `super()`. (see: https://github.com/ralph-group/pymeasure/pull/87#issuecomment-311655493)  [previously: Replace `super(...)` with direct reference to the super-class. This is in par with the way [CPython](https://github.com/python/cpython) is written.]
7. Replace three single-quotes with three double-quotes for documentation (for consistency, and also to clear yellow warnings in IDE).
8. Replace blank `except:` statements with `except Exception:` or with more specific exceptions.
9. Replace `b <= c and b >= a` kind of conditions with `a <= b <= c`.
