### PR TITLE
Fix issues in pymeasure.adapters

### DIFF
--- a/pymeasure/adapters/__init__.py
+++ b/pymeasure/adapters/__init__.py
@@ -22,10 +22,11 @@
 # THE SOFTWARE.
 #
 import logging
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
 
 from .adapter import Adapter, FakeAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 try:
     from pymeasure.adapters.visa import VISAAdapter

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -73,8 +73,8 @@ class Adapter(object):
         for i, result in enumerate(results):
             try:
                 results[i] = cast(result)
-            except:
-                pass # Keep as string
+            except Exception:
+                pass  # Keep as string
         return results
 
     def binary_values(self, command, header_bytes=0, dtype=np.float32):

--- a/pymeasure/adapters/serial.py
+++ b/pymeasure/adapters/serial.py
@@ -22,10 +22,15 @@
 # THE SOFTWARE.
 #
 
-from .adapter import Adapter
+import logging
 
 import serial
 import numpy as np
+
+from .adapter import Adapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 class SerialAdapter(Adapter):
@@ -37,7 +42,10 @@ class SerialAdapter(Adapter):
     """
 
     def __init__(self, port, **kwargs):
-        self.connection = serial.Serial(port, **kwargs)
+        if isinstance(port, serial.Serial):
+            self.connection = port
+        else:
+            self.connection = serial.Serial(port, **kwargs)
 
     def __del__(self):
         """ Ensures the connection is closed upon deletion
@@ -49,7 +57,7 @@ class SerialAdapter(Adapter):
 
         :param command: SCPI command string to be sent to the instrument
         """
-        self.connection.write(command.encode()) # encode added for Python 3
+        self.connection.write(command.encode())  # encode added for Python 3
 
     def read(self):
         """ Reads until the buffer is empty and returns the resulting

--- a/pymeasure/adapters/tests/test_adapter.py
+++ b/pymeasure/adapters/tests/test_adapter.py
@@ -22,7 +22,12 @@
 # THE SOFTWARE.
 #
 
+import logging
+
 from pymeasure.adapters import FakeAdapter
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 def test_adapter_values():

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -22,15 +22,19 @@
 # THE SOFTWARE.
 #
 
-from .adapter import Adapter
+import logging
 
+import copy
 import visa
 import numpy as np
-import copy
-import logging
+
+from .adapter import Adapter
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+
+# noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
     """ Adapter class for the VISA library using PyVISA to communicate
     to instruments. Inherit from either class VISAAdapter14 or VISAAdapter15.
@@ -38,11 +42,14 @@ class VISAAdapter(Adapter):
     :param resource: VISA resource name that identifies the address
     :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
     """
+
     def __init__(self, resourceName, **kwargs):
-        #Check PyVisa version
+        # Check PyVisa version
         version = float(self.version)
         if version < 1.7:
-            raise NotImplementedError("PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(version))
+            raise NotImplementedError(
+                "PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(
+                    version))
 
         if isinstance(resourceName, int):
             resourceName = "GPIB0::%d::INSTR" % resourceName
@@ -57,9 +64,10 @@ class VISAAdapter(Adapter):
             if key not in safeKeywords:
                 kwargs.pop(key)
         self.connection = self.manager.get_instrument(
-                                resourceName,
-                                **kwargs
-                          )
+            resourceName,
+            **kwargs
+        )
+
     @property
     def version(self):
         """ The string of the PyVISA version in use
@@ -119,9 +127,9 @@ class VISAAdapter(Adapter):
         header, data = binary[:header_bytes], binary[header_bytes:]
         return np.fromstring(data, dtype=dtype)
 
-    def config(self, is_binary = False, datatype = 'str',
-                    container = np.array, converter = 's',
-                    separator = ',', is_big_endian = False):
+    def config(self, is_binary=False, datatype='str',
+               container=np.array, converter='s',
+               separator=',', is_big_endian=False):
         """ Configurate the format of data transfer to and from the instrument.
 
         :param is_binary: If True, data is in binary format, otherwise ASCII.
@@ -132,12 +140,11 @@ class VISAAdapter(Adapter):
         :param is_big_endian: Endianness.
         """
         self.connection.values_format.is_binary = is_binary
-        self.connection.values_format.datatype  = datatype
+        self.connection.values_format.datatype = datatype
         self.connection.values_format.container = container
         self.connection.values_format.converter = converter
         self.connection.values_format.separator = separator
         self.connection.values_format.is_big_endian = is_big_endian
-
 
     def wait_for_srq(self, timeout=25, delay=0.1):
         """ Blocks until a SRQ, and leaves the bit high
@@ -145,4 +152,4 @@ class VISAAdapter(Adapter):
         :param timeout: Timeout duration in seconds
         :param delay: Time delay between checking SRQ in seconds
         """
-        self.connection.wait_for_srq(timeout*1000)
+        self.connection.wait_for_srq(timeout * 1000)


### PR DESCRIPTION
1. Make sure imports are always at the top of the file, before any other code (also clears IDE from yellow warnings).
2. Fix pep8 compatibility (spaces, blank lines, indentations).
3. Replace blank `except:` statements with `except Exception:` or with more specific exceptions.
4. Replace `super(...)` with the new `super()`. (see: https://github.com/ralph-group/pymeasure/pull/87#issuecomment-311655493)  [previously: Replace `super(...)` with direct reference to the super-class. This is in par with the way [CPython](https://github.com/python/cpython) is written.]
5. Change the way `PrologixAdapter` and 'SerialAdapter' handle `serial.Serial` object as its adapter.
6. Inherit `__del__` from `SerialAdapter` to `PrologixAdapter` instead of rewriting it.