### PR TITLE
Fix result logging

### DIFF
--- a/pymeasure/experiment/listeners.py
+++ b/pymeasure/experiment/listeners.py
@@ -43,7 +43,7 @@ except ImportError:
 class Monitor(QueueListener):
     def __init__(self, results, queue):
         console = StreamHandler()
-        console.setFormatter(results.format)
+        console.setFormatter(results.formatter)
 
         super().__init__(queue, console)
 
@@ -103,7 +103,7 @@ class Recorder(QueueListener):
         handlers = []
         for filename in results.data_filenames:
             fh = FileHandler(filename=filename, **kwargs)
-            fh.setFormatter(results.format)
+            fh.setFormatter(results.formatter)
             fh.setLevel(logging.NOTSET)
             handlers.append(fh)
 

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -24,9 +24,11 @@
 
 import logging
 
+import csv
 import os
 import re
 from datetime import datetime
+from io import StringIO
 
 import pandas as pd
 
@@ -62,31 +64,45 @@ def unique_filename(directory, prefix='DATA', suffix='', ext='csv',
 
 
 class CSVFormatter(logging.Formatter):
-    """ Formatter of data results """
+    """ Formatter of data results as csv."""
 
-    def __init__(self, columns, delimiter=','):
+    def __init__(self, columns, **kwargs):
         """Creates a csv formatter for a given list of columns (=header).
 
         :param columns: list of column names.
         :type columns: list
-        :param delimiter: delimiter between columns.
-        :type delimiter: str
         """
         super().__init__()
-        self.columns = columns
-        self.delimiter = delimiter
+        self._buffer = StringIO()
+        self._columns = columns
+        kwargs.pop('lineterminator', None)
+        self._csv = csv.DictWriter(self._buffer, self._columns, lineterminator='', **kwargs)
+
+    def _clear_buffer(self):
+        self._buffer.truncate(0)
+
+    def _read_buffer(self):
+        return self._buffer.getvalue()
 
     def format(self, record):
-        """Formats a record as csv.
+        """Formats a csv record (line).
 
         :param record: record to format.
         :type record: dict
-        :return: a string
+        :return: csv representation of the record.
         """
-        return self.delimiter.join('{}'.format(record[x]) for x in self.columns)
+        self._clear_buffer()
+        self._csv.writerow(record)
+        return self._read_buffer()
 
     def format_header(self):
-        return self.delimiter.join(self.columns)
+        """Formats the csv header.
+
+        :return: csv representation of the header.
+        """
+        self._clear_buffer()
+        self._csv.writeheader()
+        return self._read_buffer()
 
 
 class Results(object):

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -24,11 +24,9 @@
 
 import logging
 
-import csv
 import os
 import re
 from datetime import datetime
-from io import StringIO
 
 import pandas as pd
 
@@ -64,45 +62,31 @@ def unique_filename(directory, prefix='DATA', suffix='', ext='csv',
 
 
 class CSVFormatter(logging.Formatter):
-    """ Formatter of data results as csv."""
+    """ Formatter of data results """
 
-    def __init__(self, columns, **kwargs):
+    def __init__(self, columns, delimiter=','):
         """Creates a csv formatter for a given list of columns (=header).
 
         :param columns: list of column names.
         :type columns: list
+        :param delimiter: delimiter between columns.
+        :type delimiter: str
         """
         super().__init__()
-        self._buffer = StringIO()
-        self._columns = columns
-        kwargs.pop('lineterminator', None)
-        self._csv = csv.DictWriter(self._buffer, self._columns, lineterminator='', **kwargs)
-
-    def _clear_buffer(self):
-        self._buffer.truncate(0)
-
-    def _read_buffer(self):
-        return self._buffer.getvalue()
+        self.columns = columns
+        self.delimiter = delimiter
 
     def format(self, record):
-        """Formats a csv record (line).
+        """Formats a record as csv.
 
         :param record: record to format.
         :type record: dict
-        :return: csv representation of the record.
+        :return: a string
         """
-        self._clear_buffer()
-        self._csv.writerow(record)
-        return self._read_buffer()
+        return self.delimiter.join('{}'.format(record[x]) for x in self.columns)
 
     def format_header(self):
-        """Formats the csv header.
-
-        :return: csv representation of the header.
-        """
-        self._clear_buffer()
-        self._csv.writeheader()
-        return self._read_buffer()
+        return self.delimiter.join(self.columns)
 
 
 class Results(object):

--- a/pymeasure/experiment/tests/test_results.py
+++ b/pymeasure/experiment/tests/test_results.py
@@ -22,10 +22,10 @@
 # THE SOFTWARE.
 #
 
-import pytest
-
 import os
 from importlib.machinery import SourceFileLoader
+
+from pymeasure.experiment.results import CSVFormatter
 
 # Load the procedure, without it being in a module
 data_path = os.path.join(os.path.dirname(__file__), 'data/procedure_for_testing.py')
@@ -38,3 +38,18 @@ def test_procedure():
     p = procedure.TestProcedure()
     assert p.iterations == 100
     assert hasattr(p, 'execute')
+
+
+def test_csv_formatter_format_header():
+    """Tests CSVFormatter.format_header() method."""
+    columns = ['t', 'x', 'y', 'z', 'V']
+    formatter = CSVFormatter(columns=columns)
+    assert formatter.format_header() == 't,x,y,z,V'
+
+
+def test_csv_formatter_format():
+    """Tests CSVFormatter.format() method."""
+    columns = ['t', 'x', 'y', 'z', 'V']
+    formatter = CSVFormatter(columns=columns)
+    data = {'t': 1, 'y': 2, 'z': 3.0, 'x': -1, 'V': 'abc'}
+    assert formatter.format(data) == '1,-1,2,3.0,abc'

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -99,7 +99,7 @@ class Worker(StoppableProcess):
         if topic == 'results':
             self.recorder.handle(record)
         elif topic == 'status' or topic == 'progress':
-            self.monitor_queue.put((topic.decode(), record))
+            self.monitor_queue.put((topic, record))
 
     def handle_abort(self):
         log.exception("User stopped Worker execution prematurely")


### PR DESCRIPTION
1. Pass a `logging.Formatter` to `logger.setFormatter` instead of a `format()` method.
2. Don't decode `topic` when it's passed to `monitor_queue`.