### PR TITLE
Fix zmq's send/receive operations

### DIFF
--- a/pymeasure/display/listeners.py
+++ b/pymeasure/display/listeners.py
@@ -71,8 +71,7 @@ class QListener(StoppableQThread):
         self.timeout = timeout
 
     def receive(self, flags=0):
-        data = self.subscriber.recv_multipart(flags=flags)
-        topic, record = cloudpickle.loads(data)
+        topic, record = self.subscriber.recv_serialized(deserialize=cloudpickle.loads, flags=flags)
         return topic, record
 
     def message_waiting(self):

--- a/pymeasure/experiment/listeners.py
+++ b/pymeasure/experiment/listeners.py
@@ -78,8 +78,7 @@ class Listener(StoppableThread):
         self.timeout = timeout
 
     def receive(self, flags=0):
-        data = self.subscriber.recv_multipart(flags=flags)
-        topic, record = cloudpickle.loads(data)
+        topic, record = self.subscriber.recv_serialized(deserialize=cloudpickle.loads, flags=flags)
         return topic, record
 
     def message_waiting(self):

--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -92,8 +92,7 @@ class Worker(StoppableProcess):
         log.debug("Emitting message: %s %s", topic, record)
 
         try:
-            data = cloudpickle.dumps((topic, record))
-            self.publisher.send_multipart(data)
+            self.publisher.send_serialized((topic, record), serialize=cloudpickle.dumps)
         except (NameError, AttributeError):
             pass  # No dumps defined
         if topic == 'results':


### PR DESCRIPTION
Replace `send_multipart` with `send_serialized`, and `recv_multipart` with `recv_serialized`.

It solves the error encountered in the [managed window example](https://github.com/ralph-group/pymeasure/issues/90#issuecomment-316546569) in issue #90.