### PR TITLE
Delete TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,0 @@
-TODO: Add tests for all non-instrument features
-TODO: Add tests for each instrument
-TODO: Fix curve display when the only displayed item is Queued & has no data
-TODO: Fix run-away graph display on autoscale
-TODO: Fix status and progress blip (Finished, 100%) in browser item on starting to run procedure
-TODO: Work on docs
-TODO: Give an option for Results loading to ignore errors


### PR DESCRIPTION
Now that issues are tracked in the Github issue tracker, the TODO file is redundant.
See issues #98 #99 #100 #101 #102 #103