### PR TITLE
Documentation fixes

### DIFF
--- a/docs/api/instruments/validators.rst
+++ b/docs/api/instruments/validators.rst
@@ -8,3 +8,4 @@ Validators are used in conjunction with the :func:`Instrument.control <pymeasure
 
 .. automodule:: pymeasure.instruments.validators
     :members:
+    :noindex:

--- a/docs/dev/contribute.rst
+++ b/docs/dev/contribute.rst
@@ -96,6 +96,7 @@ Unit tests are run each time a new commit is made to a branch. The purpose is to
 Running the unit tests while you develop is highly encouraged. This will ensure that you have a working contribution when you create a pull request.
 
 .. code-block:: bash
+
     python setup.py test
 
 If your feature can be tested, unit tests are required. This will ensure that your features keep working as new features are added.

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -4,8 +4,6 @@ Quick start
 
 This section provides instructions for getting up and running quickly with PyMeasure.
 
-.. _installing
-
 Setting up Python
 =================
 

--- a/docs/tutorial/connecting.rst
+++ b/docs/tutorial/connecting.rst
@@ -42,19 +42,19 @@ PyMeasure supports a number of adapters, which are responsible for communicating
     adapter = VISAAdapter("GPIB::4")
     sourcemeter = Keithely2400(adapter)
 
-To instead use a Prologix GPIB device connected on :code:`/dev/ttyUSB0` (proper permissions are needed in Linux, see :ref:`PrologixAdapter`), the adapter is constructed in a similar way. Unlike the VISA adapter which is specific to each instrument, the Prologix adapter can be shared by many instruments. Therefore, they are addressed separately based on the GPIB address number when passing the adapter into the instrument construction. ::
+To instead use a Prologix GPIB device connected on :code:`/dev/ttyUSB0` (proper permissions are needed in Linux, see :class:`PrologixAdapter <pymeasure.adapters.PrologixAdapter>`), the adapter is constructed in a similar way. Unlike the VISA adapter which is specific to each instrument, the Prologix adapter can be shared by many instruments. Therefore, they are addressed separately based on the GPIB address number when passing the adapter into the instrument construction. ::
 
     from pymeasure.adapters import PrologixAdapter
 
     adapter = PrologixAdapter('/dev/ttyUSB0')
     sourcemeter = Keithley2400(adapter.gpib(4))
 
-For instruments using serial communication that have particular settings that need to be matched, a custom :ref:`Adapter` sub-class can be made. For example, the LakeShore 425 Gaussmeter connects via USB, but uses particular serial communication settings. Therefore, a :ref:`LakeShoreUSBAdapter` class enables these requirements in the background. ::
+For instruments using serial communication that have particular settings that need to be matched, a custom :class:`Adapter <pymeasure.adapters.Adapter>` sub-class can be made. For example, the LakeShore 425 Gaussmeter connects via USB, but uses particular serial communication settings. Therefore, a :class:`LakeShoreUSBAdapter <pymeasure.instruments.lakeshore.LakeShoreUSBAdapter>` class enables these requirements in the background. ::
 
     from pymeasure.instruments.lakeshore import LakeShore425
 
     gaussmeter = LakeShore425('/dev/lakeshore425')
 
-Behind the scenes the :code:`/dev/lakeshore425` port is passed to the :ref:`LakeShoreUSBAdapter`.
+Behind the scenes the :code:`/dev/lakeshore425` port is passed to the :class:`LakeShoreUSBAdapter <pymeasure.instruments.lakeshore.LakeShoreUSBAdapter>`.
 
 The above examples illustrate different methods for communicating with instruments, using adapters to keep instrument code independent from the communication protocols. Next we present the methods for setting up measurements.

--- a/docs/tutorial/procedure.rst
+++ b/docs/tutorial/procedure.rst
@@ -5,7 +5,7 @@ Making a measurement
 .. role:: python(code)
     :language: python
 
-This tutorial will walk you through using PyMeasure to acquire a current-voltage (IV) characteristic using a Keithley 2400. Even if you don't have access to this instrument, this tutorial will explain the method for making measurements with PyMeasure. First we describe using a simple script to make the measurement. From there, we show how :ref:`Procedures` objects greatly simplify the workflow, which leads to making the measurement with a graphical interface. 
+This tutorial will walk you through using PyMeasure to acquire a current-voltage (IV) characteristic using a Keithley 2400. Even if you don't have access to this instrument, this tutorial will explain the method for making measurements with PyMeasure. First we describe using a simple script to make the measurement. From there, we show how :mod:`Procedure <pymeasure.experiment.procedure>` objects greatly simplify the workflow, which leads to making the measurement with a graphical interface. 
 
 Using scripts
 =============
@@ -80,7 +80,7 @@ Running this example script will execute the measurement and save the data to a 
 * Canceling a running measurement causes the system to end in a undetermined state
 * Exceptions also end the system in an undetermined state
 
-The :ref:`Procedure` class allows us to solve all of these issues. The next section introduces the :ref:`Procedure` class and shows how to modify our script example to take advantage of these features.
+The :class:`Procedure <pymeasure.experiment.procedure.Procedure>` class allows us to solve all of these issues. The next section introduces the :class:`Procedure <pymeasure.experiment.procedure.Procedure>` class and shows how to modify our script example to take advantage of these features.
 
 
 Using Procedures

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -295,7 +295,7 @@ class ListParameter(Parameter):
 
 
 class PhysicalParameter(VectorParameter):
-    """ :class: '.VectorParameter' sub-class of 2 dimentions to store a value
+    """ :class:`.VectorParameter` sub-class of 2 dimentions to store a value
     and its uncertainty.
 
     :var value: The value of the parameter as a list of 2 floating point numbers

--- a/pymeasure/instruments/agilent/agilent34410A.py
+++ b/pymeasure/instruments/agilent/agilent34410A.py
@@ -26,9 +26,9 @@ from pymeasure.instruments import Instrument
 
 class Agilent34410A(Instrument):
     """
-    Represent the multimiters HP/Agilent/Keysight 34410A, and related
-    Implemented measurements:
-        voltage_dc, voltage_ac, current_dc, current_ac, resistance, resistance_4w
+    Represent the HP/Agilent/Keysight 34410A and related multimeters.
+
+    Implemented measurements: voltage_dc, voltage_ac, current_dc, current_ac, resistance, resistance_4w
     """
     #only the most simple functions are implemented
     voltage_dc = Instrument.measurement("MEAS:VOLT:DC? DEF,DEF", "DC voltage, in Volts")

--- a/pymeasure/instruments/agilent/agilentE4980.py
+++ b/pymeasure/instruments/agilent/agilentE4980.py
@@ -109,9 +109,11 @@ Select trigger source; accept the values:
 
     def freq_sweep(self, freq_list, return_freq=False):
         """
-        Run frequency list sweep using sequential trigger
-            :param freq_list: list of frequencies
-            :param return_freq: if True, returns the frequencies read from the instrument
+        Run frequency list sweep using sequential trigger.
+
+        :param freq_list: list of frequencies
+        :param return_freq: if True, returns the frequencies read from the instrument
+        
         Returns values as configured with :attr:`~.AgilentE4980.mode`
             """
         # manual, page 299
@@ -148,10 +150,10 @@ Select trigger source; accept the values:
     # TODO: maybe refactor as property?
     def aperture(self, time=None, averages=1):
         """
-        set and get aperture
-            :param time: integration time as string: SHORT, MED, LONG (case insensitive); 
-            if None, get values
-            :param averages: number of averages, numeric
+        Set and get aperture.
+
+        :param time: integration time as string: SHORT, MED, LONG (case insensitive); if None, get values
+        :param averages: number of averages, numeric
         """
         if time is None:
             read_values = self.ask(":APER?").split(',')

--- a/pymeasure/instruments/comedi.py
+++ b/pymeasure/instruments/comedi.py
@@ -23,15 +23,17 @@
 #
 
 from pymeasure.experiment import Procedure, Parameter, FloatParameter, IntegerParameter
-
-from pycomedi.subdevice import StreamingSubdevice
-from pycomedi.constant import *
-from pycomedi.constant import _NamedInt
-from pycomedi.channel import AnalogChannel
-from pycomedi.utility import inttrig_insn, Reader, CallbackReader
 import numpy as np
 from time import time, sleep
 from threading import Event
+from importlib.util import find_spec
+
+if find_spec('pycomedi'):  # Guard against pycomedi not being installed
+    from pycomedi.subdevice import StreamingSubdevice
+    from pycomedi.constant import *
+    from pycomedi.constant import _NamedInt
+    from pycomedi.channel import AnalogChannel
+    from pycomedi.utility import inttrig_insn, Reader, CallbackReader
 
 
 def getAI(device, channel, range=None):

--- a/pymeasure/instruments/danfysik/danfysik8500.py
+++ b/pymeasure/instruments/danfysik/danfysik8500.py
@@ -114,7 +114,7 @@ class Danfysik8500(Instrument):
     @property
     def status_hex(self):
         """ The status in hexadecimal. This value is parsed in
-        :attr:`~.status` into a human-readable list.
+        :attr:`~.Danfysik8500.status` into a human-readable list.
         """
         status = self.ask("S1H")
         match = re.search(r'(?P<hex>[A-Z0-9]{6})', status)
@@ -154,7 +154,7 @@ class Danfysik8500(Instrument):
     @property
     def current_setpoint(self):
         """ The setpoint for the current, which can deviate from the actual current
-        (:attr:`~.current`) while the supply is in the process of setting the value.
+        (:attr:`~.Danfysik8500.current`) while the supply is in the process of setting the value.
         """
         return self.current_ppm*(160/1e6)
 

--- a/pymeasure/instruments/hp/hp33120A.py
+++ b/pymeasure/instruments/hp/hp33120A.py
@@ -58,11 +58,11 @@ class HP33120A(Instrument):
     )
     max_frequency = Instrument.measurement(
         "SOUR:FREQ? MAX", 
-        """ Reads the maximum :attr:`~.frequency` in Hz for the given shape """
+        """ Reads the maximum :attr:`~.HP33120A.frequency` in Hz for the given shape """
     )
     min_frequency = Instrument.measurement(
         "SOUR:FREQ? MIN", 
-        """ Reads the minimum :attr:`~.frequency` in Hz for the given shape """
+        """ Reads the minimum :attr:`~.HP33120A.frequency` in Hz for the given shape """
     )
     amplitude = Instrument.control(
         "SOUR:VOLT?", "SOUR:VOLT %g",

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -74,7 +74,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     current = Instrument.measurement(":READ?",
         """ Reads a DC or AC current measurement in Amps, based on the
-        active :attr:`~.mode`. """
+        active :attr:`~.Keithley2000.mode`. """
     )
     current_range = Instrument.control(
         ":SENS:CURR:RANG?", ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
@@ -150,7 +150,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     voltage = Instrument.measurement(":READ?",
         """ Reads a DC or AC voltage measurement in Volts, based on the
-        active :attr:`~.mode`. """
+        active :attr:`~.Keithley2000.mode`. """
     )
     voltage_range = Instrument.control(
         ":SENS:VOLT:RANG?", ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:RANG %g",
@@ -226,7 +226,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     resistance = Instrument.measurement(":READ?",
         """ Reads a resistance measurement in Ohms for both 2-wire and 4-wire
-        configurations, based on the active :attr:`~.mode`. """
+        configurations, based on the active :attr:`~.Keithley2000.mode`. """
     )
     resistance_range = Instrument.control(
         ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
@@ -295,7 +295,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     frequency = Instrument.measurement(":READ?",
         """ Reads a frequency measurement in Hz, based on the
-        active :attr:`~.mode`. """
+        active :attr:`~.Keithley2000.mode`. """
     )
     frequency_reference = Instrument.control(
         ":SENS:FREQ:REF?", ":SENS:FREQ:REF %g",
@@ -335,7 +335,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     period = Instrument.measurement(":READ?",
         """ Reads a period measurement in seconds, based on the
-        active :attr:`~.mode`. """
+        active :attr:`~.Keithley2000.mode`. """
     )
     period_reference = Instrument.control(
         ":SENS:PER:REF?", ":SENS:PER:REF %g",
@@ -375,7 +375,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
 
     temperature = Instrument.measurement(":READ?",
         """ Reads a temperature measurement in Celsius, based on the
-        active :attr:`~.mode`. """
+        active :attr:`~.Keithley2000.mode`. """
     )
     temperature_reference = Instrument.control(
         ":SENS:TEMP:REF?", ":SENS:TEMP:REF %g",
@@ -521,7 +521,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Sets the active mode to use auto-range,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         """
         self.write(":SENS:%s:RANG:AUTO 1" % self._mode_command(mode))
 
@@ -529,7 +529,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Enables the reference for the active mode,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         """
         self.write(":SENS:%s:REF:STAT 1" % self._mode_command(mode))
 
@@ -537,7 +537,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Disables the reference for the active mode,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         """
         self.write(":SENS:%s:REF:STAT 0" % self._mode_command(mode))
 
@@ -545,7 +545,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Sets the active value as the reference for the active mode,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         """
         self.write(":SENS:%s:REF:ACQ" % self._mode_command(mode))
 
@@ -553,7 +553,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Enables the averaging filter for the active mode,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         :param type: The type of averaging filter, either 'repeat' or 'moving'.
         :param count: A number of averages, which can take take values from 1 to 100
         """
@@ -565,7 +565,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Disables the averaging filter for the active mode,
         or can set another mode by its name.
 
-        :param mode: A valid :attr:`~.mode` name, or None for the active mode
+        :param mode: A valid :attr:`~.Keithley2000.mode` name, or None for the active mode
         """
         self.write(":SENS:%s:AVER:STAT 0" % self._mode_command(mode))
 
@@ -582,7 +582,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     def remote_lock(self):
         """ Disables and locks the front panel controls to prevent
         changes during remote operations. This is disabled by
-        calling :meth:`~.local`.  """
+        calling :meth:`~.Keithley2000.local`.  """
         self.write(":SYST:RWL")
 
     def reset(self):

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -348,8 +348,8 @@ class Keithley2400(Instrument, KeithleyBuffer):
         The compliance current is also set.
 
         :param compliance_current: A float in the correct range for a 
-                                   :attr:`~.compliance_current`
-        :param voltage_range: A :attr:`~.voltage_range` value or None
+                                   :attr:`~.Keithley2400.compliance_current`
+        :param voltage_range: A :attr:`~.Keithley2400.voltage_range` value or None
         """
         log.info("%s is sourcing voltage." % self.name)
         self.source_mode = 'voltage'

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -454,7 +454,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
 
     def trigger_on_bus(self):
         """ Configures the trigger to detect events based on the bus
-        trigger, which can be activated by GET or *TRG.
+        trigger, which can be activated by :code:`GET` or :code:`*TRG`.
         """
         self.write(":ARM:COUN 1;:ARM:SOUR BUS;:TRIG:SOUR BUS;")
 


### PR DESCRIPTION
This cleans up some of the warnings that `make html` throws when generating the docs.

Note that many warnings remain where Sphinx detects identically-named attributes of different classes exist (e.g. `current`), 
```
pymeasure/pymeasure/instruments/keithley/keithley2000.py:docstring of pymeasure.instruments.keithley.Keithley2000.acquire_reference:: WARNING: more than one target found for cross-reference 'mode': pymeasure.instruments.agilent.AgilentE4980.mode, pymeasure.instruments.keithley.Keithley2000.mode
```
and sometimes picks the wrong one, e.g. `mode` [here](http://pymeasure.readthedocs.io/en/latest/api/instruments/keithley/keithley2000.html#pymeasure.instruments.keithley.Keithley2000.acquire_reference).
This is connected to sphinx-doc/sphinx#2549, I think.

Note that I put an import guard around the pycomedi code, as this otherwise throws exceptions when autodoc crawls through the code.