### PR TITLE
Add doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
     - os: linux
       env: PYTHON=3.6  CONDA_PY=36
       sudo: true
+    - os: linux
+      env: PYTHON=3.6 DOCS=true
+      sudo: true
     - os: osx
       env: PYTHON=3.4  CONDA_PY=34
       sudo: false
@@ -41,7 +44,16 @@ install:
   - ENVIRONMENT_FILE="requirements/conda-${PYTHON}.yml"
   - conda env create -f $ENVIRONMENT_FILE
   - source activate pymeasure
+  - if [ -n "${DOCS}" ]; then
+        conda install --yes sphinx sphinx_rtd_theme;
+    fi
   - conda info -a
 
 # command to run tests
-script: python setup.py test
+script: 
+  - python setup.py test
+  - if [ -n "${DOCS}" ]; then
+        cd docs;
+        make doctest || travis_terminate 1;
+        make html || travis_terminate 1;
+    fi

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,7 +139,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.autosummary'
+    'sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.doctest'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
I added the ability to run Sphinx doctests to the documentation. This also necessarily include the changes in #110, so it would be best to merge that one first, to get a smaller diff here.

To check this out. go to `doc` and run `make doctest`. Currently this executes and checks the code in the "Adding instruments" section of the docs, which lent themselves most to a first shot at this.

In the process, I extended ` FakeInstrument` a bit. Pytest tests still all pass.

@cjermain please advise how you want this integrated into the CI runners. I would just run this in addition to the pytest tests, but then we need to install sphinx in all the builds, too. Alternatively, you could have one extra builder for generating docs. This might be useful anyway elsewhere - how do you update the deployed documentation?