### PR TITLE
Exposing pyqtgraph.PlotItem API for plot display customisation

### DIFF
--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -4,6 +4,8 @@ Using a graphical interface
 
 In the previous tutorial we measured the IV characteristic of a sample to show how we can set up a simple experiment in PyMeasure. The real power of PyMeasure comes when we also use the graphical tools that are included to turn our simple example into a full-flegged user interface.
 
+.. _tutorial-plotterwindow:
+
 Using the Plotter
 ~~~~~~~~~~~~~~~~~
 
@@ -84,6 +86,7 @@ Just like the Worker, the Plotter is started in a different process so that it c
 .. image:: pymeasure-plotter.png
     :alt: Results Plotter Example
 
+.. _tutorial-managedwindow:
 
 Using the ManagedWindow
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -170,14 +173,14 @@ This results in the following graphical display.
 .. image:: pymeasure-managedwindow.png
     :alt: ManagedWindow Example
 
-In the code, the MainWindow class is a sub-class of the ManagedWindow class. We overwrite the constructor to provide information about the procedure class and its options. The :python:`inputs` are a list of Parameters class-variable names, which the display will generate graphical fields for. The :python:`displays` is a similar list, which instead defines the parameters to display in the browser window. This browser keeps track of the experiments being run in the sequential queue.
+In the code, the MainWindow class is a sub-class of the ManagedWindow class. We override the constructor to provide information about the procedure class and its options. The :code:`inputs` are a list of Parameters class-variable names, which the display will generate graphical fields for. The :code:`displays` is a similar list, which instead defines the parameters to display in the browser window. This browser keeps track of the experiments being run in the sequential queue.
 
-The :python:`queue` method establishes how the Procedure object is constructed. We use the :python:`self.make_procedure` method to create a Procedure based on the graphical input fields. Here we are free to modify the procedure before putting it on the queue. In this context, the Manager uses an Experiment object to keep track of the Procedure, Results, and its associated graphical representations in the browser and live-graph. This is then given to the Manager to queue the experiment.
+The :code:`queue` method establishes how the Procedure object is constructed. We use the :code:`self.make_procedure` method to create a Procedure based on the graphical input fields. Here we are free to modify the procedure before putting it on the queue. In this context, the Manager uses an Experiment object to keep track of the Procedure, Results, and its associated graphical representations in the browser and live-graph. This is then given to the Manager to queue the experiment.
 
 .. image:: pymeasure-managedwindow-queued.png
     :alt: ManagedWindow Queue Example
 
-By default the Manager starts a measurement when its procedure is queued. The abort button can be pressed to stop an experiment. In the Procedure, the :python:`self.should_stop` call will catch the abort event and halt the measurement. It is important to check this value, or the Procedure will not be responsive to the abort event.
+By default the Manager starts a measurement when its procedure is queued. The abort button can be pressed to stop an experiment. In the Procedure, the :code:`self.should_stop` call will catch the abort event and halt the measurement. It is important to check this value, or the Procedure will not be responsive to the abort event.
 
 .. image:: pymeasure-managedwindow-resume.png
     :alt: ManagedWindow Resume Example
@@ -188,3 +191,44 @@ If you abort a measurement, the resume button must be pressed to continue the ne
     :alt: ManagedWindow Running Example
 
 Now that you have learned about the ManagedWindow, you have all of the basics to get up and running quickly with a measurement and produce an easy to use graphical interface with PyMeasure.
+
+Customising the plot options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For both the PlotterWindow and ManagedWindow, plotting is provided by the pyqtgraph_ library. This library allows you to change various plot options, as you might expect: axis ranges (by default auto-ranging), logarithmic and semilogarithmic axes, downsampling, grid display, FFT display, etc. There are two main ways you can do this:
+
+1. You can right click on the plot to manually change any available options. This is also a good way of getting an overview of what options are available in pyqtgraph. Option changes will, of course, not persist across a restart of your program.
+2. You can programmatically set these options using pyqtgraph's PlotItem_ API, so that the window will open with these display options already set, as further explained below.
+
+For :class:`~pymeasure.display.plotter.Plotter`, you can make a sub-class that overrides the :meth:`~pymeasure.display.plotter.Plotter.setup_plot` method. This method will be called when the Plotter constructs the window. As an example ::
+
+    class LogPlotter(Plotter):
+        def setup_plot(self, plot):
+            # use logarithmic x-axis (e.g. for frequency sweeps)
+            plot.setLogMode(x=True)
+
+For :class:`~pymeasure.display.windows.ManagedWindow`, Similarly to the Plotter, the :meth:`~pymeasure.display.windows.ManagedWindow.setup_plot` method can be overridden by your sub-class in order to do the set-up ::
+
+    class MainWindow(ManagedWindow):
+
+        # ...
+
+        def setup_plot(self, plot):
+            # use logarithmic x-axis (e.g. for frequency sweeps)
+            plot.setLogMode(x=True)
+
+        # ...
+
+It is also possible to access the :attr:`~pymeasure.display.windows.ManagedWindow.plot` attribute while outside of your sub-class, for example we could modify the previous section's example ::
+
+    if __name__ == "__main__":
+        app = QtGui.QApplication(sys.argv)
+        window = MainWindow()
+        window.plot.setLogMode(x=True) # use logarithmic x-axis (e.g. for frequency sweeps)
+        window.show()
+        sys.exit(app.exec_())
+
+See pyqtgraph's API documentation on PlotItem_ for further details.
+
+.. _pyqtgraph: http://www.pyqtgraph.org/
+.. _PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -61,12 +61,10 @@ class Plotter(StoppableProcess):
     def setup_plot(self, plot):
         """
         This method does nothing by default, but can be overridden by the child
-        class in order to set up custom options for the plot
+        class in order to set up custom options for the plot window, via its
+        PlotItem_.
 
-        This method is called during the constructor, after all other set up has
-        been completed, and is provided as a convenience method to parallel Plotter.
-
-        :param plot: This window's PlotItem instance.
+        :param plot: This window's PlotItem_ instance.
 
         .. _PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
         """

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -38,6 +38,11 @@ log.addHandler(logging.NullHandler())
 class Plotter(StoppableProcess):
     """ Plotter dynamically plots data from a file through the Results
     object and supports error bars.
+
+    .. seealso::
+
+        Tutorial :ref:`tutorial-plotterwindow`
+            A tutorial and example on using the Plotter and PlotterWindow.
     """
 
     def __init__(self, results, refresh_time=0.1):
@@ -48,9 +53,24 @@ class Plotter(StoppableProcess):
     def run(self):
         app = QtGui.QApplication(sys.argv)
         window = PlotterWindow(self, refresh_time=self.refresh_time)
+        self.setup_plot(window.plot)
         app.aboutToQuit.connect(window.quit)
         window.show()
         app.exec_()
+
+    def setup_plot(self, plot):
+        """
+        This method does nothing by default, but can be overridden by the child
+        class in order to set up custom options for the plot
+
+        This method is called during the constructor, after all other set up has
+        been completed, and is provided as a convenience method to parallel Plotter.
+
+        :param plot: This window's PlotItem instance.
+
+        .. _PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
+        """
+        pass
 
     def wait_for_close(self, check_time=0.1):
         while not self.should_stop():

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -108,7 +108,11 @@ class PlotFrame(QtGui.QFrame):
         """ Returns the units of an axis by searching the string
         """
         units_pattern = "\((?P<units>\w+)\)"
-        match = re.search(units_pattern, axis)
+        try:
+            match = re.search(units_pattern, axis)
+        except TypeError:
+            match = None
+            
         if match:
             if 'units' in match.groupdict():
                 label = re.sub(units_pattern, '', axis)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -41,17 +41,22 @@ log.addHandler(logging.NullHandler())
 class PlotterWindow(QtGui.QMainWindow):
     """
     A window for plotting experiment results. Should not be
-    instantiated directly, but only via the :class:`Plotter` class.
+    instantiated directly, but only via the
+    :class:`~pymeasure.display.plotter.Plotter` class.
 
-    :attr plot: The `pyqtgraph.PlotItem`_ object for this window. Can be
+    .. seealso::
+
+        Tutorial :ref:`tutorial-plotterwindow`
+            A tutorial and example code for using the Plotter and PlotterWindow.
+
+    .. attribute plot::
+
+        The `pyqtgraph.PlotItem`_ object for this window. Can be
         accessed to further customise the plot view programmatically, e.g.,
         display log-log or semi-log axes by default, change axis range, etc.
 
     .. pyqtgraph.PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
 
-    .. seealso::
-
-        Tutorial: :ref:`tutorial-plotterwindow`
     """
     def __init__(self, plotter, refresh_time=0.1, parent=None):
         super().__init__(parent)
@@ -112,12 +117,18 @@ class ManagedWindow(QtGui.QMainWindow):
     Abstract base class.
 
     The ManagedWindow provides an interface for inputting experiment
-    parameters, running several experiments (:class:`Procedure`), plotting
+    parameters, running several experiments
+    (:class:`~pymeasure.experiment.procedure.Procedure`), plotting
     result curves, and listing the experiments conducted during a session.
 
     The ManagedWindow uses a Manager to control Workers in a Queue,
-    and provides a simple interface. The :meth:`queue` method must be overridden
-    by the child class.
+    and provides a simple interface. The :meth:`~.queue` method must be
+    overridden by the child class.
+
+    .. seealso::
+
+        Tutorial :ref:`tutorial-managedwindow`
+            A tutorial and example on the basic configuration and usage of ManagedWindow.
 
     .. attribute:: plot
 
@@ -126,11 +137,6 @@ class ManagedWindow(QtGui.QMainWindow):
         display log-log or semi-log axes by default, change axis range, etc.
 
     .. _pyqtgraph.PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
-
-    .. seealso::
-
-        Tutorial :ref:`tutorial-managedwindow`
-            A tutorial and example on the basic configuration and usage of ManagedWindow.
 
 
     """
@@ -382,8 +388,11 @@ class ManagedWindow(QtGui.QMainWindow):
         Abstract method, which must be overridden by the child class.
 
         Implementations must call ``self.manager.queue(experiment)`` and pass
-        an ``experiment`` (:class:`Experiment`) object which contains the
-        :class:`Results` and :class:`Procedure` to be run.
+        an ``experiment``
+        (:class:`~pymeasure.experiment.experiment.Experiment`) object which
+        contains the
+        :class:`~pymeasure.experiment.results.Results` and
+        :class:`~pymeasure.experiment.procedure.Procedure` to be run.
 
         For example:
 

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -39,6 +39,20 @@ log.addHandler(logging.NullHandler())
 
 
 class PlotterWindow(QtGui.QMainWindow):
+    """
+    A window for plotting experiment results. Should not be
+    instantiated directly, but only via the :class:`Plotter` class.
+
+    :attr plot: The `pyqtgraph.PlotItem`_ object for this window. Can be
+        accessed to further customise the plot view programmatically, e.g.,
+        display log-log or semi-log axes by default, change axis range, etc.
+
+    .. pyqtgraph.PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
+
+    .. seealso::
+
+        Tutorial: :ref:`tutorial-plotterwindow`
+    """
     def __init__(self, plotter, refresh_time=0.1, parent=None):
         super().__init__(parent)
         self.plotter = plotter
@@ -94,10 +108,31 @@ class PlotterWindow(QtGui.QMainWindow):
 
 
 class ManagedWindow(QtGui.QMainWindow):
-    """ The ManagedWindow uses a Manager to control Workers in a Queue,
-    and provides a simple interface. The queue method must be overwritten
-    by a child class which is required to pass an Experiment containing the
-    Results and Procedure to self.manager.queue.
+    """
+    Abstract base class.
+
+    The ManagedWindow provides an interface for inputting experiment
+    parameters, running several experiments (:class:`Procedure`), plotting
+    result curves, and listing the experiments conducted during a session.
+
+    The ManagedWindow uses a Manager to control Workers in a Queue,
+    and provides a simple interface. The :meth:`queue` method must be overridden
+    by the child class.
+
+    .. attribute:: plot
+
+        The `pyqtgraph.PlotItem`_ object for this window. Can be
+        accessed to further customise the plot view programmatically, e.g.,
+        display log-log or semi-log axes by default, change axis range, etc.
+
+    .. _pyqtgraph.PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
+
+    .. seealso::
+
+        Tutorial :ref:`tutorial-managedwindow`
+            A tutorial and example on the basic configuration and usage of ManagedWindow.
+
+
     """
     EDITOR = 'gedit'
 
@@ -116,6 +151,7 @@ class ManagedWindow(QtGui.QMainWindow):
         self.x_axis, self.y_axis = x_axis, y_axis
         self._setup_ui()
         self._layout()
+        self.setup_plot(self.plot)
 
     def _setup_ui(self):
         self.log_widget = LogWidget()
@@ -341,11 +377,44 @@ class ManagedWindow(QtGui.QMainWindow):
         self.inputs.set_parameters(parameters)
 
     def queue(self):
-        """ This method should be overwritten by the child class. The
-        self.manager.queue method should be passed an Experiment object
-        which contains the Results and Procedure to be run.
         """
-        raise Exception("ManagedWindow child class does not implement queue method")
+
+        Abstract method, which must be overridden by the child class.
+
+        Implementations must call ``self.manager.queue(experiment)`` and pass
+        an ``experiment`` (:class:`Experiment`) object which contains the
+        :class:`Results` and :class:`Procedure` to be run.
+
+        For example:
+
+        .. code-block:: python
+
+            def queue(self):
+                filename = unique_filename('results', prefix="data") # from pymeasure.experiment
+
+                procedure = self.make_procedure() # Procedure class was passed at construction
+                results = Results(procedure, filename)
+                experiment = self.new_experiment(results)
+
+                self.manager.queue(experiment)
+
+        """
+        raise NotImplementedError(
+            "Abstract method ManagedWindow.queue not implemented")
+
+    def setup_plot(self, plot):
+        """
+        This method does nothing by default, but can be overridden by the child
+        class in order to set up custom options for the plot
+
+        This method is called during the constructor, after all other set up has
+        been completed, and is provided as a convenience method to parallel Plotter.
+
+        :param plot: This window's PlotItem instance.
+
+        .. _PlotItem: http://www.pyqtgraph.org/documentation/graphicsItems/plotitem.html
+        """
+        pass
 
     def abort(self):
         self.abort_button.setEnabled(False)

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -313,7 +313,7 @@ class Results(object):
             except Exception:
                 # Empty dataframe
                 self._data = pd.DataFrame(columns=self.procedure.DATA_COLUMNS)
-        else:  # Concatenate additional data
+        else:  # Concatenate additional data, if any, to already loaded data
             skiprows = len(self._data) + self._header_count
             chunks = pd.read_csv(
                 self.data_filename,
@@ -324,8 +324,13 @@ class Results(object):
             )
             try:
                 tmp_frame = pd.concat(chunks, ignore_index=True)
-                self._data = pd.concat([self._data, tmp_frame],
-                                       ignore_index=True)
+                # only append new data if there is any
+                # if no new data, tmp_frame dtype is object, which override's
+                # self._data's original dtype - this can cause problems plotting
+                # (e.g. if trying to plot int data on a log axis)
+                if len(tmp_frame) > 0:
+                    self._data = pd.concat([self._data, tmp_frame],
+                                           ignore_index=True)
             except Exception:
                 pass  # All data is up to date
         return self._data

--- a/tests/display/test_plotter.py
+++ b/tests/display/test_plotter.py
@@ -1,0 +1,44 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from unittest import mock
+
+from pymeasure.display.Qt import QtGui, QtCore
+from pymeasure.display.plotter import Plotter
+from pymeasure.experiment.results import Results
+
+class TestPlotter:
+    # TODO: More thorough unit (or integration?) tests.
+
+    @mock.patch('pymeasure.display.plotter.PlotterWindow')
+    @mock.patch('pymeasure.display.plotter.QtGui')
+    @mock.patch.object(Plotter, 'setup_plot')
+    def test_setup_plot_called_on_init(self, mock_sp, MockQtGui, MockPlotterWindow):
+        r = mock.MagicMock(spec=Results)
+        mockplot = mock.MagicMock()
+        MockPlotterWindow.return_value = mock.MagicMock(plot=mockplot)
+        p = Plotter(r)
+        p.run() # we don't care about starting the process, just check the run
+        mock_sp.assert_called_once_with(mockplot)

--- a/tests/display/test_windows.py
+++ b/tests/display/test_windows.py
@@ -1,0 +1,50 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+from unittest import mock
+
+from pymeasure.display.Qt import QtGui, QtCore
+from pymeasure.display.windows import ManagedWindow
+from pymeasure.experiment.procedure import Procedure
+
+class TestManagedWindow:
+    # TODO: More thorough unit (or integration?) tests.
+
+    # TODO: Could we make this more testable? These patches are a bit ridiculous.
+    @mock.patch('pymeasure.display.windows.Manager')
+    @mock.patch('pymeasure.display.windows.InputsWidget')
+    @mock.patch('pymeasure.display.windows.BrowserWidget')
+    @mock.patch('pymeasure.display.windows.PlotWidget')
+    @mock.patch('pymeasure.display.windows.QtGui')
+    @mock.patch.object(ManagedWindow, 'setCentralWidget')
+    @mock.patch.object(ManagedWindow, 'addDockWidget')
+    @mock.patch.object(ManagedWindow, 'setup_plot')
+    def test_setup_plot_called_on_init(self, mock_sp, mock_a, mock_b,
+            MockQtGui, MockPlotWidget, MockBrowserWidget, MockInputsWidget,
+            MockManager, qtbot):
+        mock_procedure = mock.MagicMock(spec=Procedure)
+        w = ManagedWindow(mock_procedure)
+        qtbot.addWidget(w)
+        mock_sp.assert_called_once_with(w.plot)

--- a/tests/experiment/test_results.py
+++ b/tests/experiment/test_results.py
@@ -22,12 +22,17 @@
 # THE SOFTWARE.
 #
 
+import pytest
+from unittest import mock
+
 import os
 import tempfile
 import pickle
 from importlib.machinery import SourceFileLoader
+import pandas as pd
 
 from pymeasure.experiment.results import Results, CSVFormatter
+from pymeasure.experiment.procedure import Procedure
 
 # Load the procedure, without it being in a module
 #data_path = os.path.join(os.path.dirname(__file__), 'data/procedure_for_testing.py')
@@ -69,3 +74,30 @@ def test_procedure_wrapper():
     assert hasattr(new_results, 'procedure')
     assert new_results.procedure.iterations == 101
     assert RandomProcedure.iterations.value == 100
+
+
+class TestResults:
+    # TODO: add a full set of Results tests
+
+    @mock.patch('pymeasure.experiment.results.open', mock.mock_open(), create=True)
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('pymeasure.experiment.results.pd.read_csv')
+    def test_regression_attr_data_when_up_to_date_should_retain_dtype(self,
+            read_csv_mock, path_exists_mock):
+        procedure_mock = mock.MagicMock(spec=Procedure)
+        result = Results(procedure_mock, 'test.csv')
+
+        read_csv_mock.return_value = [pd.DataFrame(data={
+                'A': [1,2,3,4,5,6,7],
+                'B': [2,3,4,5,6,7,8]
+            })]
+        first_data = result.data
+
+        # if no updates, read_csv returns a zero-row dataframe
+        read_csv_mock.return_value = [pd.DataFrame(data={
+            'A': [], 'B': []
+            }, dtype=object)]
+        second_data = result.data
+
+        assert second_data.iloc[:,0].dtype is not object
+        assert first_data.iloc[:,0].dtype is second_data.iloc[:,0].dtype


### PR DESCRIPTION
Fixes #120. These changes expose convenient, documented means for a `pymeasure` user to customise the plot display, e.g. using logarithmic axes, setting axis ranges, etc.

This pull request introduces new APIs, and does not introduce breaking changes.

* `ManagedWindow.plot` and `PlotterWindow.plot` attributes are now documented, public APIs.
* Added `ManagedWindow.setup_plot()` and `Plotter.setup_plot()`: these methods are NOOP and can be overridden in sub-classes or monkey-patched to customise the plot display. It's necessary for the Plotter (as the window is created in a separate process), and provided in ManagedWindow as a convenience method to better organise code (as otherwise it would be possible to set it up via `ManagedWindow.plot` after object construction).
* Added tests for the above.
* Added feature documentation in the tutorial and API docs.
