### PR TITLE
VISA minor version handling

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -38,18 +38,15 @@ log.addHandler(logging.NullHandler())
 # noinspection PyPep8Naming,PyUnresolvedReferences
 class VISAAdapter(Adapter):
     """ Adapter class for the VISA library using PyVISA to communicate
-    to instruments. Inherit from either class VISAAdapter14 or VISAAdapter15.
+    with instruments.
 
     :param resource: VISA resource name that identifies the address
     :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
     """
 
     def __init__(self, resourceName, **kwargs):
-        # Check PyVisa version
-        if self.version < parse_version('1.7'):
-            raise NotImplementedError(
-                "PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(
-                    self.version.public))
+        if not VISAAdapter.has_supported_version():
+            raise NotImplementedError("Please upgrade PyVISA to version 1.8 or later.")
 
         if isinstance(resourceName, int):
             resourceName = "GPIB0::%d::INSTR" % resourceName
@@ -68,14 +65,13 @@ class VISAAdapter(Adapter):
             **kwargs
         )
 
-    @property
-    def version(self):
-        """ The string of the PyVISA version in use
-        """
+    @staticmethod
+    def has_supported_version():
+        """ Returns True if the PyVISA version is greater than 1.8 """
         if hasattr(visa, '__version__'):
-            return parse_version(visa.__version__)
+            return parse_version(visa.__version__) >= parse_version('1.8')
         else:
-            return parse_version('1.4')
+            return False
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resourceName

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -27,6 +27,7 @@ import logging
 import copy
 import visa
 import numpy as np
+from pkg_resources import parse_version
 
 from .adapter import Adapter
 
@@ -45,11 +46,10 @@ class VISAAdapter(Adapter):
 
     def __init__(self, resourceName, **kwargs):
         # Check PyVisa version
-        version = float(self.version)
-        if version < 1.7:
+        if self.version < parse_version('1.7'):
             raise NotImplementedError(
                 "PyVisa {} is no longer supported. Please upgrade to version 1.8 or later.".format(
-                    version))
+                    self.version.public))
 
         if isinstance(resourceName, int):
             resourceName = "GPIB0::%d::INSTR" % resourceName
@@ -73,9 +73,9 @@ class VISAAdapter(Adapter):
         """ The string of the PyVISA version in use
         """
         if hasattr(visa, '__version__'):
-            return visa.__version__
+            return parse_version(visa.__version__)
         else:
-            return '1.4'
+            return parse_version('1.4')
 
     def __repr__(self):
         return "<VISAAdapter(resource='%s')>" % self.connection.resourceName

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -1,0 +1,28 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.adapters import VISAAdapter
+
+def test_visa_version():
+  assert VISAAdatper.has_supported_version()

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -25,4 +25,4 @@
 from pymeasure.adapters import VISAAdapter
 
 def test_visa_version():
-  assert VISAAdatper.has_supported_version()
+  assert VISAAdapter.has_supported_version()


### PR DESCRIPTION
This PR uses `pkg_resources` to handle version comparison of minor versions in PyVISA, as reported in #130 and #134.