### PR TITLE
Added Ametek 7270 Lockin

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -11,3 +11,4 @@ Neal Reynolds
 Christoph Buchner
 Julian Dlugosch
 Sylvain Karlen
+Joseph Mittelstaedt

--- a/pymeasure/instruments/ametek/__init__.py
+++ b/pymeasure/instruments/ametek/__init__.py
@@ -22,23 +22,4 @@
 # THE SOFTWARE.
 #
 
-from ..errors import RangeError, RangeException
-from .instrument import Instrument
-from .mock import Mock
-from .resources import list_resources
-from .validators import discreteTruncate
-
-from . import agilent
-from . import ametek
-from . import anritsu
-from . import danfysik
-from . import fwbell
-from . import hp
-from . import keithley
-from . import lakeshore
-from . import parker
-from . import signalrecovery
-from . import srs
-from . import tektronix
-from . import thorlabs
-from . import yokogawa
+from .ametek7270 import Ametek7270

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,0 +1,179 @@
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import modular_range, truncated_discrete_set, truncated_range
+
+class Ametek7270(Instrument):
+    """This is the class for the Ametek DSP 7270 lockin amplifier"""
+
+
+    sensitivity = Instrument.control( # NOTE: only for IMODE = 1 for now. Not sure if validator is used correctly for now...
+        "SEN.", "SEN %d",
+        """ A floating point property that controls the sensitivity
+        range in Volts, which can take discrete values from 2 nV to
+        1 V. This property can be set. """,
+        validator=truncated_discrete_set,
+        values=[
+            0.0, 2.0e-9, 5.0e-9, 10.0e-9, 20.0e-9, 50.0e-9, 100.0e-9,
+            200.0e-9, 500.0e-9, 1.0e-6, 2.0e-6, 5.0e-6, 10.0e-6,
+            20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
+            2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0
+        ],
+        map_values=True
+    )
+    slope = Instrument.control(
+        "SLOPE", "SLOPE %d",
+        """ A integer property that controls the filter slope in
+        dB/octave, which can take the values 6, 12, 18, or 24 dB/octave.
+        This property can be set. """,
+        validator=truncated_discrete_set,
+        values=[6, 12, 18, 24],
+        map_values=True
+    )
+    time_constant = Instrument.control( # NOTE: only for NOISEMODE = 0
+        "TC.", "TC %d",
+        """ A floating point property that controls the time constant
+        in seconds, which takes values from 10 microseconds to 100,000
+        seconds. This property can be set. """,
+        validator=truncated_discrete_set,
+        values=[
+            10.0e-6, 20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6,
+            1.0e-3, 2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
+            100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
+            20.0e3, 50.0e3, 100.0e3
+        ],
+        map_values=True
+    )
+    x = Instrument.measurement("X.",
+        """ Reads the X value in Volts """
+    )
+    y = Instrument.measurement("Y.",
+        """ Reads the Y value in Volts """
+    )
+    x1 = Instrument.measurement("X1.",
+        """ Reads the first harmonic X value in Volts """
+    )
+    y1 = Instrument.measurement("Y1.",
+        """ Reads the Y value in Volts """
+    )
+    x2 = Instrument.measurement("X2.",
+        """ Reads the second harmonic X value in Volts """
+    )
+    y2 = Instrument.measurement("Y2.",
+        """ Reads the second harmonic Y value in Volts """
+    )
+    xy = Instrument.measurement("XY.",
+        """ Reads both the X and Y values in Volts """
+    )
+    mag = Instrument.measurement("MAG.",
+        """ Reads the magnitude in Volts """
+    )
+    harmonic = Instrument.control(
+        "REFN", "REFN %d",
+        """ An integer property that represents the reference
+        harmonic mode control, taking values from 1 to 127.
+        This property can be set. """,
+        validator=truncated_discrete_set,
+        values=list(range(1,128))
+    )
+    phase = Instrument.control(
+        "REFP.", "REFP. %g",
+        """ A floating point property that represents the reference
+        harmonic phase in degrees. This property can be set. """,
+        validator=modular_range,
+        values=[0,360]
+    )
+    voltage = Instrument.control(
+        "OA.", "OA. %g",
+        """ A floating point property that represents the voltage
+        in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[0,5]
+    )
+    frequency = Instrument.control(
+        "OF.", "OF. %g",
+        """ A floating point property that represents the lock-in
+        frequency in Hz. This property can be set. """,
+        validator=truncated_range,
+        values=[0,2.5e5]
+    )
+    dac1 = Instrument.control(
+        "DAC. 1", "DAC. 1 %g",
+        """ A floating point property that represents the output
+        value on DAC1 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-10,10]
+    )
+    dac2 = Instrument.control(
+        "DAC. 2", "DAC. 2 %g",
+        """ A floating point property that represents the output
+        value on DAC2 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-10,10]
+    )
+    dac3 = Instrument.control(
+        "DAC. 3", "DAC. 3 %g",
+        """ A floating point property that represents the output
+        value on DAC3 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-10,10]
+    )
+    dac4 = Instrument.control(
+        "DAC. 4", "DAC. 4 %g",
+        """ A floating point property that represents the output
+        value on DAC4 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-10,10]
+    )
+    adc1 = Instrument.measurement("ADC. 1",
+        """ Reads the input value of ADC1 in Volts """
+    )
+    adc2 = Instrument.measurement("ADC. 2",
+        """ Reads the input value of ADC2 in Volts """
+    )
+    adc3 = Instrument.measurement("ADC. 3",
+        """ Reads the input value of ADC3 in Volts """
+    )
+    adc4 = Instrument.measurement("ADC. 4",
+        """ Reads the input value of ADC4 in Volts """
+    )
+    id = Instrument.measurement("ID",
+        """ Reads the instrument identification """
+    )
+
+    def __init__(self, resourceName, **kwargs):
+        super(Ametek7270, self).__init__(
+            resourceName,
+            "Ametek DSP 7270",
+            **kwargs
+        )
+
+    def set_voltage_mode(self):
+        """ Sets instrument to voltage control mode """
+        self.write("IMODE 0")
+
+    def set_differential_mode(self, lineFiltering=True):
+        """ Sets instrument to differential mode -- assuming it is in voltage mode """
+        self.write("VMODE 3")
+        self.write("LF %d 0" % 3 if lineFiltering else 0)
+
+    def set_channel_A_mode(self):
+        """ Sets instrument to channel A mode -- assuming it is in voltage mode """
+        self.write("VMODE 1")
+
+    @property
+    def auto_gain(self):
+        return (int(self.ask("AUTOMATIC")) == 1)
+
+    @auto_gain.setter
+    def auto_gain(self, setval):
+        if setval:
+            self.write("AUTOMATIC 1")
+        else:
+            self.write("AUTOMATIC 0")
+
+    # TODO: shutdown function. Not sure what defaults should be, if any needed for it.

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,3 +1,27 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -48,15 +48,8 @@ class Instrument(object):
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
-            if isinstance(adapter, str):
-                daqform = re.compile('Dev\d{1,}')
-                matchdaq = daqform.fullmatch(adapter)
-                pxiform = re.compile('PXI\d{1,}Slot\d{1,}')
-                matchpxi = pxiform.fullmatch(adapter)
-                if matchdaq or matchpxi:
-                    pass
-                elif isinstance(adapter, (int, str)):
-                    adapter = VISAAdapter(adapter, **kwargs)
+            if isinstance(adapter, (int, str)):
+                adapter = VISAAdapter(adapter, **kwargs)
         except ImportError:
             raise Exception("Invalid Adapter provided for Instrument since "
                             "PyVISA is not present")

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -35,8 +35,8 @@ log.addHandler(logging.NullHandler())
 
 
 class Instrument(object):
-    """ This provides the base class for all Instruments, which is 
-    independent of the particular Adapter used to connect for 
+    """ This provides the base class for all Instruments, which is
+    independent of the particular Adapter used to connect for
     communication to the instrument. It provides basic SCPI commands
     by default, but can be toggled with :code:`includeSCPI`.
 
@@ -48,8 +48,15 @@ class Instrument(object):
     # noinspection PyPep8Naming
     def __init__(self, adapter, name, includeSCPI=True, **kwargs):
         try:
-            if isinstance(adapter, (int, str)):
-                adapter = VISAAdapter(adapter, **kwargs)
+            if isinstance(adapter, str):
+                daqform = re.compile('Dev\d{1,}')
+                matchdaq = daqform.fullmatch(adapter)
+                pxiform = re.compile('PXI\d{1,}Slot\d{1,}')
+                matchpxi = pxiform.fullmatch(adapter)
+                if matchdaq or matchpxi:
+                    pass
+                elif isinstance(adapter, (int, str)):
+                    adapter = VISAAdapter(adapter, **kwargs)
         except ImportError:
             raise Exception("Invalid Adapter provided for Instrument since "
                             "PyVISA is not present")
@@ -120,7 +127,7 @@ class Instrument(object):
                 check_set_errors=False, check_get_errors=False,
                 **kwargs):
         """Returns a property for the class based on the supplied
-        commands. This property may be set and read from the 
+        commands. This property may be set and read from the
         instrument.
 
         :param get_command: A string command that asks for the value
@@ -130,14 +137,14 @@ class Instrument(object):
                           and returns a valid value, while it otherwise raises an exception
         :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
-        :param map_values: A boolean flag that determines if the values should be 
+        :param map_values: A boolean flag that determines if the values should be
                           interpreted as a map
-        :param get_process: A function that take a value and allows processing 
+        :param get_process: A function that take a value and allows processing
                             before value mapping, returning the processed value
         :param set_process: A function that takes a value and allows processing
                             before value mapping, returning the processed value
         :param check_set_errors: Toggles checking errors after setting
-        :param check_get_errors: Toggles checking errors after getting        
+        :param check_get_errors: Toggles checking errors after getting
         """
 
         if map_values and isinstance(values, dict):
@@ -192,20 +199,20 @@ class Instrument(object):
                     get_process=lambda v: v, command_process=lambda c: c,
                     check_get_errors=False, **kwargs):
         """ Returns a property for the class based on the supplied
-        commands. This is a measurement quantity that may only be 
+        commands. This is a measurement quantity that may only be
         read from the instrument, not set.
 
         :param get_command: A string command that asks for the value
         :param docs: A docstring that will be included in the documentation
         :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
-        :param map_values: A boolean flag that determines if the values should be 
+        :param map_values: A boolean flag that determines if the values should be
                           interpreted as a map
-        :param get_process: A function that take a value and allows processing 
+        :param get_process: A function that take a value and allows processing
                             before value mapping, returning the processed value
         :param command_process: A function that take a command and allows processing
                             before executing the command, for both getting and setting
-        :param check_get_errors: Toggles checking errors after getting 
+        :param check_get_errors: Toggles checking errors after getting
         """
 
         if map_values and isinstance(values, dict):
@@ -246,14 +253,14 @@ class Instrument(object):
         """Returns a property for the class based on the supplied
         commands. This property may be set, but raises an exception
         when being read from the instrument.
-        
+
         :param set_command: A string command that writes the value
         :param docs: A docstring that will be included in the documentation
         :param validator: A function that takes both a value and a group of valid values
                           and returns a valid value, while it otherwise raises an exception
         :param values: A list, tuple, range, or dictionary of valid values, that can be used
                        as to map values if :code:`map_values` is True.
-        :param map_values: A boolean flag that determines if the values should be 
+        :param map_values: A boolean flag that determines if the values should be
                           interpreted as a map
         :param set_process: A function that takes a value and allows processing
                             before value mapping, returning the processed value

--- a/pymeasure/instruments/ni/daqmx.py
+++ b/pymeasure/instruments/ni/daqmx.py
@@ -50,7 +50,7 @@ class DAQmx(object):
     """Instrument object for interfacing with NI-DAQmx devices."""
     def __init__(self, name, *args, **kwargs):
         super(DAQmx, self).__init__()
-        self.resourceName = name
+        self.resourceName = name # NOTE: Device number, e.g. Dev1 or PXI1Slot2
         self.numChannels = 0
         self.numSamples = 0
         self.dataBuffer = 0
@@ -77,7 +77,7 @@ class DAQmx(object):
                                 DAQmx_Val_Rising,DAQmx_Val_FiniteSamps,
                                 uInt64(self.numSamples)));
 
-    def setupAnalogVoltageOut(self, channel=0):
+    def setup_analog_voltage_out(self, channel=0):
         resourceString = self.resourceName + "/ao" + str(channel)
         self.taskHandleAO = TaskHandle(0)
         self.CHK(nidaq.DAQmxCreateTask("", ctypes.byref( self.taskHandleAO )))
@@ -86,7 +86,7 @@ class DAQmx(object):
                 float64(-10.0), float64(10.0),
                 DAQmx_Val_Volts, None))
 
-    def setupAnalogVoltageOutMultipleChannels(self, channelList):
+    def setup_analog_voltage_out_multiple_channels(self, channelList):
         resourceString = ""
         for num, channel in enumerate(channelList):
             if num > 0:
@@ -99,20 +99,19 @@ class DAQmx(object):
                 float64(-10.0), float64(10.0),
                 DAQmx_Val_Volts, None))
 
-
-    def writeAnalogVoltage(self, value):
-        timeout = -1.0 
+    def write_analog_voltage(self, value):
+        timeout = -1.0
         self.CHK(nidaq.DAQmxWriteAnalogScalarF64( self.taskHandleAO,
-            1, # Autostart 
-            float64(timeout), 
-            float64(value), 
+            1, # Autostart
+            float64(timeout),
+            float64(value),
             None))
 
-    def writeAnalogVoltageMultipleChannels(self, values):
-        timeout = -1.0 
+    def write_analog_voltage_multiple_channels(self, values):
+        timeout = -1.0
         self.CHK(nidaq.DAQmxWriteAnalogF64( self.taskHandleAO,
             1, # Samples per channel
-            1, # Autostart 
+            1, # Autostart
             float64(timeout),
             DAQmx_Val_GroupByChannel,
             (np.array(values)).ctypes.data,
@@ -122,10 +121,10 @@ class DAQmx(object):
         read = int32()
         self.CHK(nidaq.DAQmxReadAnalogF64(self.taskHandleAI ,self.numSamples,float64(10.0),
                                 DAQmx_Val_GroupByChannel, self.dataBuffer.ctypes.data,
-                                self.numChannels*self.numSamples,ctypes.byref(read),None))  
+                                self.numChannels*self.numSamples,ctypes.byref(read),None))
         return self.dataBuffer.transpose()
 
-    def acquireAverage(self):
+    def acquire_average(self):
         if not self.terminated:
             avg = np.mean(self.acquire(), axis=1)
             return avg

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -31,7 +31,7 @@ import numpy as np
 
 class DSP7265(Instrument):
     """This is the class for the DSP 7265 lockin amplifier"""
-
+    # TODO: add regultors on most of these
     voltage = Instrument.control(
         "OA.", "OA. %g",
         """ A floating point property that represents the voltage
@@ -41,7 +41,7 @@ class DSP7265(Instrument):
         "OF.", "OF. %g",
         """ A floating point property that represents the lock-in
         frequency in Hz. This property can be set. """
-    ) 
+    )
     dac1 = Instrument.control(
         "DAC. 1", "DAC. 1 %g",
         """ A floating point property that represents the output
@@ -73,22 +73,22 @@ class DSP7265(Instrument):
         """ A floating point property that represents the reference
         harmonic phase in degrees. This property can be set. """
     )
-    x = Instrument.measurement("X.", 
+    x = Instrument.measurement("X.",
         """ Reads the X value in Volts """
     )
-    y = Instrument.measurement("Y.", 
+    y = Instrument.measurement("Y.",
         """ Reads the Y value in Volts """
     )
-    xy = Instrument.measurement("X.Y.", 
+    xy = Instrument.measurement("X.Y.",
         """ Reads both the X and Y values in Volts """
     )
-    mag = Instrument.measurement("Mag.", 
+    mag = Instrument.measurement("Mag.", # TODO: Should be capitalized?
         """ Reads the magnitude in Volts """
     )
-    adc1 = Instrument.measurement("ADC. 1", 
+    adc1 = Instrument.measurement("ADC. 1",
         """ Reads the input value of ADC1 in Volts """
     )
-    adc2 = Instrument.measurement("ADC. 2", 
+    adc2 = Instrument.measurement("ADC. 2",
         """ Reads the input value of ADC2 in Volts """
     )
     id = Instrument.measurement("ID",
@@ -97,7 +97,7 @@ class DSP7265(Instrument):
     sensitivity = Instrument.control(
         "SEN.", "SEN %d",
         """ A floating point property that controls the sensitivity
-        range in Volts, which can take discrete values from 2 nV to 
+        range in Volts, which can take discrete values from 2 nV to
         1 V. This property can be set. """,
         validator=truncated_discrete_set,
         values=[
@@ -106,7 +106,7 @@ class DSP7265(Instrument):
             20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
             2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
             200.0e-3, 500.0e-3, 1.0
-        ]
+        ] # TODO: Determine if map_values = True here!!!
     )
     slope = Instrument.control(
         "SLOPE", "SLOPE %d",
@@ -129,7 +129,7 @@ class DSP7265(Instrument):
             200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
             100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
             20.0e3, 50.0e3
-        ]
+        ] # TODO: Determine if map_values = True here!!!
     )
 
     def __init__(self, resourceName, **kwargs):
@@ -147,7 +147,7 @@ class DSP7265(Instrument):
             'ADC2': 64,
             'ADC3': 128
         }
-        
+
         # Pre-condition
         self.adapter.config(datatype = 'str', converter = 's')
 
@@ -159,7 +159,7 @@ class DSP7265(Instrument):
             return [float(x) for x in result.split(",")]
         except:
             return result
-        
+
     def setDifferentialMode(self, lineFiltering=True):
         self.write("VMODE 3")
         self.write("LF %d 0" % 3 if lineFiltering else 0)

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -23,7 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import truncated_discrete_set
+from pymeasure.instruments.validators import truncated_discrete_set, truncated_range, modular_range
 
 from time import sleep
 import numpy as np
@@ -31,47 +31,63 @@ import numpy as np
 
 class DSP7265(Instrument):
     """This is the class for the DSP 7265 lockin amplifier"""
-    # TODO: add regultors on most of these
+
     voltage = Instrument.control(
         "OA.", "OA. %g",
         """ A floating point property that represents the voltage
-        in Volts. This property can be set. """
+        in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[0,5]
     )
     frequency = Instrument.control(
         "OF.", "OF. %g",
         """ A floating point property that represents the lock-in
-        frequency in Hz. This property can be set. """
+        frequency in Hz. This property can be set. """,
+        validator=truncated_range,
+        values=[0,2.5e5]
     )
     dac1 = Instrument.control(
         "DAC. 1", "DAC. 1 %g",
         """ A floating point property that represents the output
-        value on DAC1 in Volts. This property can be set. """
+        value on DAC1 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-12,12]
     )
     dac2 = Instrument.control(
         "DAC. 2", "DAC. 2 %g",
         """ A floating point property that represents the output
-        value on DAC2 in Volts. This property can be set. """
+        value on DAC2 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-12,12]
     )
     dac3 = Instrument.control(
         "DAC. 3", "DAC. 3 %g",
         """ A floating point property that represents the output
-        value on DAC3 in Volts. This property can be set. """
+        value on DAC3 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-12,12]
     )
     dac4 = Instrument.control(
         "DAC. 4", "DAC. 4 %g",
         """ A floating point property that represents the output
-        value on DAC4 in Volts. This property can be set. """
+        value on DAC4 in Volts. This property can be set. """,
+        validator=truncated_range,
+        values=[-12,12]
     )
     harmonic = Instrument.control(
         "REFN", "REFN %d",
         """ An integer property that represents the reference
         harmonic mode control, taking values from 1 to 65535.
-        This property can be set. """
+        This property can be set. """,
+        validator=truncated_discrete_set,
+        values=list(range(65535))
     )
     phase = Instrument.control(
         "REFP.", "REFP. %g",
         """ A floating point property that represents the reference
-        harmonic phase in degrees. This property can be set. """
+        harmonic phase in degrees. This property can be set. """,
+        validator=modular_range,
+        values=[0,360]
     )
     x = Instrument.measurement("X.",
         """ Reads the X value in Volts """
@@ -106,7 +122,8 @@ class DSP7265(Instrument):
             20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
             2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
             200.0e-3, 500.0e-3, 1.0
-        ] # TODO: Determine if map_values = True here!!!
+        ],
+        map_values=True
     )
     slope = Instrument.control(
         "SLOPE", "SLOPE %d",
@@ -129,7 +146,8 @@ class DSP7265(Instrument):
             200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
             100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
             20.0e3, 50.0e3
-        ] # TODO: Determine if map_values = True here!!!
+        ],
+        map_values=True
     )
 
     def __init__(self, resourceName, **kwargs):

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -72,6 +72,31 @@ def truncated_range(value, values):
         return min(values)
 
 
+def modular_range(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the range. Otherwise it returns the value,
+    modulo the max of the range.
+
+    :param value: a value to test
+    :param values: A set of values that are valid
+    """
+    return value % max(values)
+
+
+def modular_range_bidirectional(value, values):
+    """ Provides a validator function that returns the value
+    if it is in the range. Otherwise it returns the value,
+    modulo the max of the range. Allows negative values.
+
+    :param value: a value to test
+    :param values: A set of values that are valid
+    """
+    if value > 0:
+        return value % max(values)
+    else:
+        return -1 * (abs(value) % max(values))
+
+
 def truncated_discrete_set(value, values):
     """ Provides a validator function that returns the value
     if it is in the discrete set. Otherwise, it returns the smallest

--- a/tests/instruments/test_validators.py
+++ b/tests/instruments/test_validators.py
@@ -61,21 +61,21 @@ def test_truncated_discrete_set():
 
 def test_modular_range():
     assert modular_range(5, range(10)) == 5
-    assert modular_range(5.1, range(10)) == pytest.approx(5.1)
+    assert abs(modular_range(5.1, range(10)) - 5.1) < 1e-6
     assert modular_range(11, range(10)) == 2
-    assert modular_range(11.3, range(10)) == pytest.approx(2.3)
-    assert modular_range(-7.1, range(10)) == pytest.approx(1.9)
-    assert modular_range(-13.2, range(10)) == pytest.approx(4.8)
+    assert abs(modular_range(11.3, range(10)) - 2.3) < 1e-6
+    assert abs(modular_range(-7.1, range(10)) - 1.9) < 1e-6
+    assert abs(modular_range(-13.2, range(10)) - 4.8) < 1e-6
 
 
 def test_modular_range_bidirectional():
     assert modular_range_bidirectional(5, range(10)) == 5
-    assert modular_range_bidirectional(5.1, range(10)) == pytest.approx(5.1)
+    assert abs(modular_range_bidirectional(5.1, range(10)) - 5.1) < 1e-6
     assert modular_range_bidirectional(11, range(10)) == 2
-    assert modular_range_bidirectional(11.3, range(10)) == pytest.approx(2.3)
+    assert abs(modular_range_bidirectional(11.3, range(10)) - 2.3) < 1e-6
     assert modular_range_bidirectional(-7, range(10)) == -7
-    assert modular_range_bidirectional(-7.1, range(10)) == pytest.approx(-7.1)
-    assert modular_range_bidirectional(-13.2, range(10)) == pytest.approx(-4.2)
+    assert abs(modular_range_bidirectional(-7.1, range(10)) - (-7.1)) < 1e-6
+    assert abs(modular_range_bidirectional(-13.2, range(10)) - (-4.2)) < 1e-6
 
 
 def test_joined_validators():

--- a/tests/instruments/test_validators.py
+++ b/tests/instruments/test_validators.py
@@ -23,7 +23,6 @@
 #
 
 import pytest
-from math import isclose
 from pymeasure.instruments.validators import (
     strict_range, strict_discrete_set,
     truncated_range, truncated_discrete_set,
@@ -62,20 +61,21 @@ def test_truncated_discrete_set():
 
 def test_modular_range():
     assert modular_range(5, range(10)) == 5
-    assert isclose(modular_range(5.1, range(10)), 5.1, rel_tol=1e-10)
+    assert modular_range(5.1, range(10)) == pytest.approx(5.1)
     assert modular_range(11, range(10)) == 2
-    assert isclose(modular_range(11.3, range(10)), 2.3, rel_tol=1e-10)
-    assert isclose(modular_range(-7.1, range(10)), 1.9, rel_tol=1e-10)
-    assert isclose(modular_range(-13.2, range(10)), 4.8, rel_tol=1e-10)
+    assert modular_range(11.3, range(10)) == pytest.approx(2.3)
+    assert modular_range(-7.1, range(10)) == pytest.approx(1.9)
+    assert modular_range(-13.2, range(10)) == pytest.approx(4.8)
+
 
 def test_modular_range_bidirectional():
     assert modular_range_bidirectional(5, range(10)) == 5
-    assert isclose(modular_range_bidirectional(5.1, range(10)), 5.1, rel_tol=1e-10)
+    assert modular_range_bidirectional(5.1, range(10)) == pytest.approx(5.1)
     assert modular_range_bidirectional(11, range(10)) == 2
-    assert isclose(modular_range_bidirectional(11.3, range(10)), 2.3, rel_tol=1e-10)
+    assert modular_range_bidirectional(11.3, range(10)) == pytest.approx(2.3)
     assert modular_range_bidirectional(-7, range(10)) == -7
-    assert isclose(modular_range_bidirectional(-7.1, range(10)), -7.1, rel_tol=1e-10)
-    assert isclose(modular_range_bidirectional(-13.2, range(10)), -4.2, rel_tol=1e-10)
+    assert modular_range_bidirectional(-7.1, range(10)) == pytest.approx(-7.1)
+    assert modular_range_bidirectional(-13.2, range(10)) == pytest.approx(-4.2)
 
 
 def test_joined_validators():

--- a/tests/instruments/test_validators.py
+++ b/tests/instruments/test_validators.py
@@ -23,9 +23,11 @@
 #
 
 import pytest
+from math import isclose
 from pymeasure.instruments.validators import (
     strict_range, strict_discrete_set,
     truncated_range, truncated_discrete_set,
+    modular_range, modular_range_bidirectional,
     joined_validators
 )
 
@@ -57,6 +59,23 @@ def test_truncated_discrete_set():
     assert truncated_discrete_set(5.1, range(10)) == 6
     assert truncated_discrete_set(11, range(10)) == 9
     assert truncated_discrete_set(-10, range(10)) == 0
+
+def test_modular_range():
+    assert modular_range(5, range(10)) == 5
+    assert isclose(modular_range(5.1, range(10)), 5.1, rel_tol=1e-10)
+    assert modular_range(11, range(10)) == 1
+    assert isclose(modular_range(11.3, range(10)), 1.3, rel_tol=1e-10)
+    assert isclose(modular_range(-7.1, range(10)), 2.9, rel_tol=1e-10)
+    assert isclose(modular_range(-13.2, range(10)), 6.8, rel_tol=1e-10)
+
+def test_modular_range_bidirectional():
+    assert modular_range_bidirectional(5, range(10)) == 5
+    assert isclose(modular_range_bidirectional(5.1, range(10)), 5.1, rel_tol=1e-10)
+    assert modular_range_bidirectional(11, range(10)) == 1
+    assert isclose(modular_range_bidirectional(11.3, range(10)), 1.3, rel_tol=1e-10)
+    assert modular_range_bidirectional(-7, range(10)) == -7
+    assert isclose(modular_range_bidirectional(-7.1, range(10)), -7.1, rel_tol=1e-10)
+    assert isclose(modular_range_bidirectional(-13.2, range(10)), -3.2, rel_tol=1e-10)
 
 
 def test_joined_validators():

--- a/tests/instruments/test_validators.py
+++ b/tests/instruments/test_validators.py
@@ -63,19 +63,19 @@ def test_truncated_discrete_set():
 def test_modular_range():
     assert modular_range(5, range(10)) == 5
     assert isclose(modular_range(5.1, range(10)), 5.1, rel_tol=1e-10)
-    assert modular_range(11, range(10)) == 1
-    assert isclose(modular_range(11.3, range(10)), 1.3, rel_tol=1e-10)
-    assert isclose(modular_range(-7.1, range(10)), 2.9, rel_tol=1e-10)
-    assert isclose(modular_range(-13.2, range(10)), 6.8, rel_tol=1e-10)
+    assert modular_range(11, range(10)) == 2
+    assert isclose(modular_range(11.3, range(10)), 2.3, rel_tol=1e-10)
+    assert isclose(modular_range(-7.1, range(10)), 1.9, rel_tol=1e-10)
+    assert isclose(modular_range(-13.2, range(10)), 4.8, rel_tol=1e-10)
 
 def test_modular_range_bidirectional():
     assert modular_range_bidirectional(5, range(10)) == 5
     assert isclose(modular_range_bidirectional(5.1, range(10)), 5.1, rel_tol=1e-10)
-    assert modular_range_bidirectional(11, range(10)) == 1
-    assert isclose(modular_range_bidirectional(11.3, range(10)), 1.3, rel_tol=1e-10)
+    assert modular_range_bidirectional(11, range(10)) == 2
+    assert isclose(modular_range_bidirectional(11.3, range(10)), 2.3, rel_tol=1e-10)
     assert modular_range_bidirectional(-7, range(10)) == -7
     assert isclose(modular_range_bidirectional(-7.1, range(10)), -7.1, rel_tol=1e-10)
-    assert isclose(modular_range_bidirectional(-13.2, range(10)), -3.2, rel_tol=1e-10)
+    assert isclose(modular_range_bidirectional(-13.2, range(10)), -4.2, rel_tol=1e-10)
 
 
 def test_joined_validators():


### PR DESCRIPTION
Hi,

Changelist:
- New instrument driver for the Ametek 7270 DSP Lockin amplifier. 
- New validator function called `modular_range`, useful for inputting degrees.
    - Related new validator called `modular_range_bidirectional` which accounts for possible negative values, i.e. -1 mod 365 is usually 364 but you may want -1returned instead.
- Added validators on all of the Signal Recovery DSP 7265 Lockin amplifier's properties.