### PR TITLE
Reverting Qt to 4.11 instead of 5.6

### DIFF
--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -4,7 +4,7 @@ dependencies:
 - pandas=0.19.2=np112py36_1
 - pip=9.0.1=py36_1
 - py=1.4.34=py36_0
-- pyqt=5.6.0=py36_2
+- pyqt=4.11
 - pyqtgraph=0.10.0=py36_0
 - pyserial=2.7=py36_0
 - pytest=3.1.1=py36_0

--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -4,7 +4,7 @@ dependencies:
 - pandas=0.19.2=np112py36_1
 - pip=9.0.1=py36_1
 - py=1.4.34=py36_0
-- pyqt=4.11
+- pyqt=4.11.4
 - pyqtgraph=0.10.0=py36_0
 - pyserial=2.7=py36_0
 - pytest=3.1.1=py36_0


### PR DESCRIPTION
The Python 3.6 requirement file is not consistent with the Python 3.5 tests in terms of the Qt version. This PR reverts the version of Qt to 4.11 from 5.6 for those tests. This is intended to solve an issue found during the tests of #146.