### PR TITLE
Modifying Instruments

### DIFF
--- a/docs/api/instruments/ametek/ametek7270.rst
+++ b/docs/api/instruments/ametek/ametek7270.rst
@@ -2,6 +2,6 @@
 Ametek 7270 DSP Lockin Amplifier
 ################################
 
-.. autoclass:: pymeasure.instruments.danfysik.Danfysik8500
+.. autoclass:: pymeasure.instruments.ametek.Ametek7270
     :members:
     :show-inheritance:

--- a/docs/api/instruments/ametek/ametek7270.rst
+++ b/docs/api/instruments/ametek/ametek7270.rst
@@ -1,0 +1,7 @@
+################################
+Ametek 7270 DSP Lockin Amplifier
+################################
+
+.. autoclass:: pymeasure.instruments.danfysik.Danfysik8500
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/ametek/index.rst
+++ b/docs/api/instruments/ametek/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.ametek
+
+######
+Ametek
+######
+
+This section contains specific documentation on the Ametek instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   ametek7270

--- a/pymeasure/adapters/adapter.py
+++ b/pymeasure/adapters/adapter.py
@@ -72,7 +72,12 @@ class Adapter(object):
         results = results.split(separator)
         for i, result in enumerate(results):
             try:
-                results[i] = cast(result)
+                if cast == bool:
+                    # Need to cast to float first since results are usually
+                    # strings and bool of a non-empty string is always True
+                    results[i] = bool(float(result))
+                else:
+                    results[i] = cast(result)
             except Exception:
                 pass  # Keep as string
         return results

--- a/pymeasure/instruments/agilent/agilent8257D.py
+++ b/pymeasure/instruments/agilent/agilent8257D.py
@@ -176,6 +176,50 @@ class Agilent8257D(Instrument):
         values=[0.1, 10e6]
     )
 
+    ########################
+    # Low-Frequency Output #
+    ########################
+
+    low_freq_out_amplitude = Instrument.control(
+        ":SOUR:LFO:AMPL? ", ":SOUR:LFO:AMPL %g VP",
+        """A floating point property that controls the peak voltage (amplitude) of the
+        low frequency output in volts, which can take values from 0-3.5V""",
+        validator=truncated_range,
+        values=[0,3.5]
+    )
+
+    LOW_FREQUENCY_SOURCES = {
+        'internal':'INT', 'internal 2':'INT2', 'function':'FUNC', 'function 2':'FUNC2'
+    }
+
+    low_freq_out_source = Instrument.control(
+        ":SOUR:LFO:SOUR?", ":SOUR:LFO:SOUR %s",
+        """A string property which controls the source of the low frequency output, which
+        can take the values 'internal [2]' for the inernal source, or 'function [2]' for an internal
+        function generator which can be configured.""",
+        validator=strict_discrete_set,
+        values=LOW_FREQUENCY_SOURCES,
+        map_values=True
+    )
+
+    def enable_low_freq_out(self):
+        """Enables low frequency output"""
+        self.write(":SOUR:LFO:STAT ON")
+
+    def disable_low_freq_out(self):
+        """Disables low frequency output"""
+        self.write(":SOUR:LFO:STAT OFF")
+
+    def config_low_freq_out(self, source='internal', amplitude=3):
+        """ Configures the low-frequency output signal.
+
+        :param source: The source for the low-frequency output signal.
+        :param amplitude: Amplitude of the low-frequency output
+        """
+        self.enable_low_freq_out()
+        self.low_freq_out_source = source
+        self.low_freq_out_amplitude = amplitude
+
     #######################
     # Internal Oscillator #
     #######################
@@ -233,7 +277,7 @@ class Agilent8257D(Instrument):
         self.enable_amplitude_modulation()
         self.amplitude_source = 'internal'
         self.internal_frequency = frequency
-        self.internal_shape = 'sine'
+        self.internal_shape = shape
         self.amplitude_depth = depth
 
     def enable_amplitude_modulation(self):
@@ -252,7 +296,7 @@ class Agilent8257D(Instrument):
         """
         self.enable_pulse_modulation()
         self.pulse_source = 'internal'
-        self.pulse_input = 'square'
+        self.pulse_input = input
         self.pulse_frequency = frequency
 
     def enable_pulse_modulation(self):

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -84,16 +84,16 @@ class Ametek7270(Instrument):
         """ Reads the Y value in Volts """
     )
     x1 = Instrument.measurement("X1.",
-        """ Reads the X value in Volts """
+        """ Reads the first harmonic X value in Volts """
     )
     y1 = Instrument.measurement("Y1.",
-        """ Reads the Y value in Volts """
+        """ Reads the first harmonic Y value in Volts """
     )
     x2 = Instrument.measurement("X2.",
-        """ Reads the X value in Volts """
+        """ Reads the second harmonic X value in Volts """
     )
     y2 = Instrument.measurement("Y2.",
-        """ Reads the Y value in Volts """
+        """ Reads the second harmonic Y value in Volts """
     )
     xy = Instrument.measurement("XY.",
         """ Reads both the X and Y values in Volts """

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,27 +1,3 @@
-#
-# This file is part of the PyMeasure package.
-#
-# Copyright (c) 2013-2017 PyMeasure Developers
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -32,6 +8,21 @@ from pymeasure.instruments.validators import modular_range, truncated_discrete_s
 class Ametek7270(Instrument):
     """This is the class for the Ametek DSP 7270 lockin amplifier"""
 
+    SENSITIVITIES = [
+            0.0, 2.0e-9, 5.0e-9, 10.0e-9, 20.0e-9, 50.0e-9, 100.0e-9,
+            200.0e-9, 500.0e-9, 1.0e-6, 2.0e-6, 5.0e-6, 10.0e-6,
+            20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
+            2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0
+        ]
+
+    TIME_CONSTANTS = [
+            10.0e-6, 20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6,
+            1.0e-3, 2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
+            100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
+            20.0e3, 50.0e3, 100.0e3
+        ]
 
     sensitivity = Instrument.control( # NOTE: only for IMODE = 1 for now. Not sure if validator is used correctly for now...
         "SEN.", "SEN %d",
@@ -39,13 +30,7 @@ class Ametek7270(Instrument):
         range in Volts, which can take discrete values from 2 nV to
         1 V. This property can be set. """,
         validator=truncated_discrete_set,
-        values=[
-            0.0, 2.0e-9, 5.0e-9, 10.0e-9, 20.0e-9, 50.0e-9, 100.0e-9,
-            200.0e-9, 500.0e-9, 1.0e-6, 2.0e-6, 5.0e-6, 10.0e-6,
-            20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
-            2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
-            200.0e-3, 500.0e-3, 1.0
-        ],
+        values=SENSITIVITIES,
         map_values=True
     )
     slope = Instrument.control(
@@ -63,15 +48,11 @@ class Ametek7270(Instrument):
         in seconds, which takes values from 10 microseconds to 100,000
         seconds. This property can be set. """,
         validator=truncated_discrete_set,
-        values=[
-            10.0e-6, 20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6,
-            1.0e-3, 2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
-            200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
-            100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
-            20.0e3, 50.0e3, 100.0e3
-        ],
+        values=TIME_CONSTANTS,
         map_values=True
     )
+    # TODO: Figure out if this actually can send for X1. X2. Y1. Y2. or not.
+    #       There's nothing in the manual about it but UtilMOKE sends these.
     x = Instrument.measurement("X.",
         """ Reads the X value in Volts """
     )
@@ -79,16 +60,16 @@ class Ametek7270(Instrument):
         """ Reads the Y value in Volts """
     )
     x1 = Instrument.measurement("X1.",
-        """ Reads the first harmonic X value in Volts """
+        """ Reads the X value in Volts """
     )
     y1 = Instrument.measurement("Y1.",
         """ Reads the Y value in Volts """
     )
     x2 = Instrument.measurement("X2.",
-        """ Reads the second harmonic X value in Volts """
+        """ Reads the X value in Volts """
     )
     y2 = Instrument.measurement("Y2.",
-        """ Reads the second harmonic Y value in Volts """
+        """ Reads the Y value in Volts """
     )
     xy = Instrument.measurement("XY.",
         """ Reads both the X and Y values in Volts """
@@ -200,4 +181,8 @@ class Ametek7270(Instrument):
         else:
             self.write("AUTOMATIC 0")
 
-    # TODO: shutdown function. Not sure what defaults should be, if any needed for it.
+    def shutdown(self):
+        """ Ensures the instrument in a safe state """
+        self.voltage = 0.
+        self.isShutdown = True
+        log.info("Shutting down %s" % self.name)

--- a/pymeasure/instruments/ametek/ametek7270.py
+++ b/pymeasure/instruments/ametek/ametek7270.py
@@ -1,3 +1,27 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
 import logging
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -24,7 +48,7 @@ class Ametek7270(Instrument):
             20.0e3, 50.0e3, 100.0e3
         ]
 
-    sensitivity = Instrument.control( # NOTE: only for IMODE = 1 for now. Not sure if validator is used correctly for now...
+    sensitivity = Instrument.control( # NOTE: only for IMODE = 1.
         "SEN.", "SEN %d",
         """ A floating point property that controls the sensitivity
         range in Volts, which can take discrete values from 2 nV to

--- a/pymeasure/instruments/keithley/keithley2000.py
+++ b/pymeasure/instruments/keithley/keithley2000.py
@@ -58,9 +58,9 @@ class Keithley2000(Instrument, KeithleyBuffer):
     mode = Instrument.control(
         ":CONF?", ":CONF:%s",
         """ A string property that controls the configuration mode for measurements,
-        which can take the values: :code:'current' (DC), :code:'current ac', 
-        :code:'voltage' (DC),  :code:'voltage ac', :code:'resistance' (2-wire), 
-        :code:'resistance 4W' (4-wire), :code:'period', :code:'frequency', 
+        which can take the values: :code:'current' (DC), :code:'current ac',
+        :code:'voltage' (DC),  :code:'voltage ac', :code:'resistance' (2-wire),
+        :code:'resistance 4W' (4-wire), :code:'period', :code:'frequency',
         :code:'temperature', :code:'diode', and :code:'frequency'. """,
         validator=strict_discrete_set,
         values=MODES,
@@ -79,11 +79,11 @@ class Keithley2000(Instrument, KeithleyBuffer):
     current_range = Instrument.control(
         ":SENS:CURR:RANG?", ":SENS:CURR:RANG:AUTO 0;:SENS:CURR:RANG %g",
         """ A floating point property that controls the DC current range in
-        Amps, which can take values from 0 to 3.1 A. 
+        Amps, which can take values from 0 to 3.1 A.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[0, 3.1]
-    )  
+    )
     current_reference = Instrument.control(
         ":SENS:CURR:REF?", ":SENS:CURR:REF %g",
         """ A floating point property that controls the DC current reference
@@ -94,7 +94,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     current_nplc = Instrument.control(
         ":SENS:CURR:NPLC?", ":SENS:CURR:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the DC current measurements, which sets the integration period 
+        (NPLC) for the DC current measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -109,7 +109,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     current_ac_range = Instrument.control(
         ":SENS:CURR:AC:RANG?", ":SENS:CURR:AC:RANG:AUTO 0;:SENS:CURR:AC:RANG %g",
         """ A floating point property that controls the AC current range in
-        Amps, which can take values from 0 to 3.1 A. 
+        Amps, which can take values from 0 to 3.1 A.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[0, 3.1]
@@ -124,7 +124,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     current_ac_nplc = Instrument.control(
         ":SENS:CURR:AC:NPLC?", ":SENS:CURR:AC:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the AC current measurements, which sets the integration period 
+        (NPLC) for the AC current measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -170,7 +170,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     voltage_nplc = Instrument.control(
         ":SENS:CURRVOLT:NPLC?", ":SENS:VOLT:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the DC voltage measurements, which sets the integration period 
+        (NPLC) for the DC voltage measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -185,7 +185,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     voltage_ac_range = Instrument.control(
         ":SENS:VOLT:AC:RANG?", ":SENS:VOLT:RANG:AUTO 0;:SENS:VOLT:AC:RANG %g",
         """ A floating point property that controls the AC voltage range in
-        Volts, which can take values from 0 to 757.5 V. 
+        Volts, which can take values from 0 to 757.5 V.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[0, 757.5]
@@ -200,7 +200,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     voltage_ac_nplc = Instrument.control(
         ":SENS:VOLT:AC:NPLC?", ":SENS:VOLT:AC:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the AC voltage measurements, which sets the integration period 
+        (NPLC) for the AC voltage measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -230,8 +230,8 @@ class Keithley2000(Instrument, KeithleyBuffer):
     )
     resistance_range = Instrument.control(
         ":SENS:RES:RANG?", ":SENS:RES:RANG:AUTO 0;:SENS:RES:RANG %g",
-        """ A floating point property that controls the 2-wire resistance range 
-        in Ohms, which can take values from 0 to 120 MOhms. 
+        """ A floating point property that controls the 2-wire resistance range
+        in Ohms, which can take values from 0 to 120 MOhms.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[0, 120e6]
@@ -246,7 +246,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     resistance_nplc = Instrument.control(
         ":SENS:RES:NPLC?", ":SENS:RES:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the 2-wire resistance measurements, which sets the integration period 
+        (NPLC) for the 2-wire resistance measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -261,7 +261,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     resistance_4W_range = Instrument.control(
         ":SENS:FRES:RANG?", ":SENS:FRES:RANG:AUTO 0;:SENS:FRES:RANG %g",
         """ A floating point property that controls the 4-wire resistance range
-        in Ohms, which can take values from 0 to 120 MOhms. 
+        in Ohms, which can take values from 0 to 120 MOhms.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[0, 120e6]
@@ -276,7 +276,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     resistance_4W_nplc = Instrument.control(
         ":SENS:FRES:NPLC?", ":SENS:FRES:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the 4-wire resistance measurements, which sets the integration period 
+        (NPLC) for the 4-wire resistance measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -387,7 +387,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     temperature_nplc = Instrument.control(
         ":SENS:TEMP:NPLC?", ":SENS:TEMP:NPLC %g",
         """ A floating point property that controls the number of power line cycles
-        (NPLC) for the temperature measurements, which sets the integration period 
+        (NPLC) for the temperature measurements, which sets the integration period
         and measurement speed. Takes values from 0.01 to 10, where 0.1, 1, and 10 are
         Fast, Medium, and Slow respectively. """
     )
@@ -512,7 +512,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
         """ Configures the instrument to perform continuity testing. """
         self.mode = 'continuity'
 
-    def _mode_command(mode=None):
+    def _mode_command(self, mode=None):
         if mode is None:
             mode = self.mode
         return self.MODES[mode]
@@ -570,12 +570,12 @@ class Keithley2000(Instrument, KeithleyBuffer):
         self.write(":SENS:%s:AVER:STAT 0" % self._mode_command(mode))
 
     def local(self):
-        """ Returns control to the instrument panel, and enables 
+        """ Returns control to the instrument panel, and enables
         the panel if disabled. """
         self.write(":SYST:LOC")
 
     def remote(self):
-        """ Places the instrument in the remote state, which is 
+        """ Places the instrument in the remote state, which is
         does not need to be explicity called in general. """
         self.write(":SYST:REM")
 
@@ -588,7 +588,7 @@ class Keithley2000(Instrument, KeithleyBuffer):
     def reset(self):
         """ Resets the instrument state. """
         self.write(":STAT:QUEUE:CLEAR;*RST;:STAT:PRES;:*CLS;")
-        
+
     def beep(self, frequency, duration):
         """ Sounds a system beep.
 

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -175,7 +175,7 @@ class Axis(object):
         "MD?",
         """ Returns a boolean that is True if the motion is finished.
         """,
-        get_process=lambda x: bool(x)
+        cast=bool
     )
 
     def __init__(self, axis, controller):

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -70,8 +70,8 @@ class AxisError(Exception):
 
     def __init__(self, code):
         self.axis = str(code)[0]
-        self.error = str(code)[1:] 
-        self.message = self.MESSAGES[self.error]      
+        self.error = str(code)[1:]
+        self.message = self.MESSAGES[self.error]
 
     def __str__(self):
         return "Newport ESP300 axis %s reported the error: %s" % (
@@ -119,7 +119,7 @@ class GeneralError(Exception):
 
     def __init__(self, code):
         self.error = str(code)
-        self.message = self.MESSAGES[self.error]      
+        self.message = self.MESSAGES[self.error]
 
     def __str__(self):
         return "Newport ESP300 reported the error: %s" % (
@@ -175,7 +175,7 @@ class Axis(object):
         "MD?",
         """ Returns a boolean that is True if the motion is finished.
         """,
-        get_process=lambda x: bool(x) # JM: Changed this, it works now
+        get_process=lambda x: bool(x)
     )
 
     def __init__(self, axis, controller):
@@ -219,7 +219,7 @@ class Axis(object):
         self.write("DH")
 
     def wait_for_stop(self, delay=0, interval=0.05):
-        """ Blocks the program until the motion is completed. A further 
+        """ Blocks the program until the motion is completed. A further
         delay can be specified in seconds.
         """
         self.write("WS%d" % (delay*1e3))
@@ -313,4 +313,3 @@ class ESP300(Instrument):
         """ Shuts down the controller by disabling all of the axes.
         """
         self.disable()
-

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -202,11 +202,13 @@ class Axis(object):
         """ Disables motion for the axis. """
         self.write("MF")
 
-    def home(self, htype=1):
+    def home(self, type=1):
         """ Drives the axis to the home position, which may be the negative
         hardware limit for some actuators (e.g. LTA-HS).
+        type can take integer values from 0 to 6.
         """
-        self.write("OR%d" % htype)
+        home_type = strict_discrete_set(type, [0,1,2,3,4,5,6])
+        self.write("OR%d" % home_type)
 
     def define_position(self, position):
         """ Overwrites the value of the current position with the given

--- a/pymeasure/instruments/newport/esp300.py
+++ b/pymeasure/instruments/newport/esp300.py
@@ -77,7 +77,6 @@ class AxisError(Exception):
         return "Newport ESP300 axis %s reported the error: %s" % (
             self.axis, self.message)
 
-
 class GeneralError(Exception):
     """ Raised when the Newport ESP300 has a general error.
     """
@@ -176,7 +175,7 @@ class Axis(object):
         "MD?",
         """ Returns a boolean that is True if the motion is finished.
         """,
-        cast=bool
+        get_process=lambda x: bool(x) # JM: Changed this, it works now
     )
 
     def __init__(self, axis, controller):
@@ -203,11 +202,11 @@ class Axis(object):
         """ Disables motion for the axis. """
         self.write("MF")
 
-    def home(self, type=1):
+    def home(self, htype=1):
         """ Drives the axis to the home position, which may be the negative
         hardware limit for some actuators (e.g. LTA-HS).
         """
-        self.write("OR%d")
+        self.write("OR%d" % htype)
 
     def define_position(self, position):
         """ Overwrites the value of the current position with the given
@@ -223,7 +222,7 @@ class Axis(object):
         """ Blocks the program until the motion is completed. A further 
         delay can be specified in seconds.
         """
-        self.write("WS%g" % delay*1e3)
+        self.write("WS%d" % (delay*1e3))
         while not self.motion_done:
             sleep(interval)
 

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -22,8 +22,12 @@
 # THE SOFTWARE.
 #
 
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import truncated_discrete_set, truncated_range, modular_range
+from pymeasure.instruments.validators import truncated_discrete_set, truncated_range, modular_range, modular_range_bidirectional, strict_discrete_set
 
 from time import sleep
 import numpy as np
@@ -31,6 +35,24 @@ import numpy as np
 
 class DSP7265(Instrument):
     """This is the class for the DSP 7265 lockin amplifier"""
+    # TODO: add regultors on most of these
+
+    SENSITIVITIES = [
+            0.0, 2.0e-9, 5.0e-9, 10.0e-9, 20.0e-9, 50.0e-9, 100.0e-9,
+            200.0e-9, 500.0e-9, 1.0e-6, 2.0e-6, 5.0e-6, 10.0e-6,
+            20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
+            2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0
+        ]
+
+    TIME_CONSTANTS = [
+            10.0e-6, 20.0e-6, 40.0e-6, 80.0e-6, 160.0e-6, 320.0e-6,
+            640.0e-6, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
+            200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
+            100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
+            20.0e3, 50.0e3
+        ]
+    REFERENCES = ['internal', 'external rear', 'external front']
 
     voltage = Instrument.control(
         "OA.", "OA. %g",
@@ -86,7 +108,7 @@ class DSP7265(Instrument):
         "REFP.", "REFP. %g",
         """ A floating point property that represents the reference
         harmonic phase in degrees. This property can be set. """,
-        validator=modular_range,
+        validator=modular_range_bidirectional,
         values=[0,360]
     )
     x = Instrument.measurement("X.",
@@ -98,7 +120,7 @@ class DSP7265(Instrument):
     xy = Instrument.measurement("X.Y.",
         """ Reads both the X and Y values in Volts """
     )
-    mag = Instrument.measurement("Mag.", # TODO: Should be capitalized?
+    mag = Instrument.measurement("MAG.",
         """ Reads the magnitude in Volts """
     )
     adc1 = Instrument.measurement("ADC. 1",
@@ -110,19 +132,21 @@ class DSP7265(Instrument):
     id = Instrument.measurement("ID",
         """ Reads the instrument identification """
     )
+    reference = Instrument.control(
+        "IE", "IE %d",
+        """Controls the oscillator reference. Can be "internal", 
+        "external rear" or "external front" """,
+        validator=strict_discrete_set,
+        values=REFERENCES,
+        map_values=True
+    )
     sensitivity = Instrument.control(
-        "SEN.", "SEN %d",
+        "SEN", "SEN %d",
         """ A floating point property that controls the sensitivity
         range in Volts, which can take discrete values from 2 nV to
         1 V. This property can be set. """,
         validator=truncated_discrete_set,
-        values=[
-            0.0, 2.0e-9, 5.0e-9, 10.0e-9, 20.0e-9, 50.0e-9, 100.0e-9,
-            200.0e-9, 500.0e-9, 1.0e-6, 2.0e-6, 5.0e-6, 10.0e-6,
-            20.0e-6, 50.0e-6, 100.0e-6, 200.0e-6, 500.0e-6, 1.0e-3,
-            2.0e-3, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
-            200.0e-3, 500.0e-3, 1.0
-        ],
+        values=SENSITIVITIES,
         map_values=True
     )
     slope = Instrument.control(
@@ -140,13 +164,7 @@ class DSP7265(Instrument):
         in seconds, which takes values from 10 microseconds to 50,000
         seconds. This property can be set. """,
         validator=truncated_discrete_set,
-        values=[
-            10.0e-6, 20.0e-6, 40.0e-6, 80.0e-6, 160.0e-6, 320.0e-6,
-            640.0e-6, 5.0e-3, 10.0e-3, 20.0e-3, 50.0e-3, 100.0e-3,
-            200.0e-3, 500.0e-3, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0,
-            100.0, 200.0, 500.0, 1.0e3, 2.0e3, 5.0e3, 10.0e3,
-            20.0e3, 50.0e3
-        ],
+        values=TIME_CONSTANTS,
         map_values=True
     )
 
@@ -178,7 +196,12 @@ class DSP7265(Instrument):
         except:
             return result
 
+
+    def set_voltage_mode(self):
+        self.write("IMODE 0")
+
     def setDifferentialMode(self, lineFiltering=True):
+        """Sets lockin to differential mode, measuring A-B"""
         self.write("VMODE 3")
         self.write("LF %d 0" % 3 if lineFiltering else 0)
 
@@ -227,21 +250,6 @@ class DSP7265(Instrument):
     def gain(self, value):
         self.write("ACGAIN %d" % int(value/10.0))
 
-    @property
-    def reference(self):
-        return "external" if int(self.ask("IE")) == 2 else "internal"
-
-    @reference.setter
-    def reference(self, value):
-        if value == "internal":
-            val = 0
-        elif value == "external":
-            val = 2
-        else:
-            raise Exception("Incorrect value for reference type."
-                            " Must be either internal or extenal.")
-        self.write("IE %d" % val)
-
     def set_buffer(self, points, quantities=['x'], interval=10.0e-3):
         num = 0
         for q in quantities:
@@ -280,3 +288,8 @@ class DSP7265(Instrument):
                 return data
         else:
             return [0.0]
+
+    def shutdown(self):
+        log.info("Shutting down %s." % self.name)
+        self.voltage = 0.
+        self.isShutdown = True

--- a/pymeasure/instruments/signalrecovery/dsp7265.py
+++ b/pymeasure/instruments/signalrecovery/dsp7265.py
@@ -134,7 +134,7 @@ class DSP7265(Instrument):
     )
     reference = Instrument.control(
         "IE", "IE %d",
-        """Controls the oscillator reference. Can be "internal", 
+        """Controls the oscillator reference. Can be "internal",
         "external rear" or "external front" """,
         validator=strict_discrete_set,
         values=REFERENCES,
@@ -159,7 +159,7 @@ class DSP7265(Instrument):
         map_values=True
     )
     time_constant = Instrument.control(
-        "TC.", "TC %d",
+        "TC", "TC %d",
         """ A floating point property that controls the time constant
         in seconds, which takes values from 10 microseconds to 50,000
         seconds. This property can be set. """,


### PR DESCRIPTION
Hello,

I improved the instrument drivers for the ametek7270, newport esp300 and signalrecovery dsp7265. For the dsp7265, I also expanded the functionality of the reference signal specification, but it is *not backwards compatible.* what was previously called `external` only referred to the front-panel external reference. This has been renamed to `external front` and the option `external rear` has been added.
I also added documentation for the ametek7270. I followed the format of the other instruments so I'm assuming this was done correctly.