### PR TITLE
Fix "mininums" -> "minimums" in Keithley2400.py

### DIFF
--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -548,7 +548,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
     @property
     def min_current(self):
         """ Returns the minimum current from the buffer """
-        return self.mininums[1]
+        return self.minimums[1]
 
     @property
     def std_current(self):


### PR DESCRIPTION
Spelling error caused crash when attempting to poll the minimum current from a keithley2400 buffer.