### PR TITLE
Fix/visa adapter

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -55,7 +55,7 @@ class VISAAdapter(Adapter):
         self.manager = visa.ResourceManager()
         safeKeywords = ['resource_name', 'timeout',
                         'chunk_size', 'lock', 'delay', 'send_end',
-                        'values_format', 'read_termination']
+                        'values_format', 'read_termination', 'write_termination']
         kwargsCopy = copy.deepcopy(kwargs)
         for key in kwargsCopy:
             if key not in safeKeywords:

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -44,7 +44,7 @@ class VISAAdapter(Adapter):
     :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
     """
 
-    def __init__(self, resourceName, **kwargs):
+    def __init__(self, resourceName, visa_library='', **kwargs):
         if not VISAAdapter.has_supported_version():
             raise NotImplementedError("Please upgrade PyVISA to version 1.8 or later.")
 
@@ -52,7 +52,7 @@ class VISAAdapter(Adapter):
             resourceName = "GPIB0::%d::INSTR" % resourceName
         super(VISAAdapter, self).__init__()
         self.resource_name = resourceName
-        self.manager = visa.ResourceManager()
+        self.manager = visa.ResourceManager(visa_library)
         safeKeywords = ['resource_name', 'timeout',
                         'chunk_size', 'lock', 'delay', 'send_end',
                         'values_format', 'read_termination', 'write_termination']

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -41,6 +41,8 @@ class VISAAdapter(Adapter):
     with instruments.
 
     :param resource: VISA resource name that identifies the address
+    :param visa_library: VisaLibrary Instance, path of the VISA library or VisaLibrary spec string (@py or @ni).
+                         if not given, the default for the platform will be used.
     :param kwargs: Any valid key-word arguments for constructing a PyVISA instrument
     """
 

--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -53,7 +53,7 @@ class VISAAdapter(Adapter):
         super(VISAAdapter, self).__init__()
         self.resource_name = resourceName
         self.manager = visa.ResourceManager()
-        safeKeywords = ['resource_name', 'timeout', 'term_chars',
+        safeKeywords = ['resource_name', 'timeout',
                         'chunk_size', 'lock', 'delay', 'send_end',
                         'values_format', 'read_termination']
         kwargsCopy = copy.deepcopy(kwargs)


### PR DESCRIPTION
Hi,

Here is the fix of the visa adapter so that write_termination is now a safe keyword (#170) .
Looking at the adapter, could we also add an argument to configure the backend?
something like:

`self.manager = visa.ResourceManager(backend)`

Right now my way to change the backend is to set the environment variable

`os.environ['PYVISA_LIBRARY'] = '@py`

