### PR TITLE
Adding the basic function of Keysight N5767A power supply

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -15,3 +15,4 @@ Joseph Mittelstaedt
 Troy Fox
 Vikram Sekar
 Casper Schippers
+Sumatran Tiger

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -19,3 +19,4 @@ The following developers have contributed to the PyMeasure package:
 | Julian Dlugosch
 | Vikram Sekar
 | Casper Schippers
+| Sumatran Tiger

--- a/docs/api/instruments/keysight/index.rst
+++ b/docs/api/instruments/keysight/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.keysight
+
+########
+Keysight
+########
+
+This section contains specific documentation on the keysight instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   keysightN5767A

--- a/docs/api/instruments/keysight/keysightN5767A.rst
+++ b/docs/api/instruments/keysight/keysightN5767A.rst
@@ -1,0 +1,9 @@
+########################
+keysight N5767A power supply
+########################
+
+.. autoclass:: pymeasure.instruments.keysight.KeysightN5767A
+    :members:
+    :show-inheritance:
+    :inherited-members:
+    :exclude-members: ask, control, clear, measurement, read, setting, values, write

--- a/docs/api/instruments/keysight/keysightN5767A.rst
+++ b/docs/api/instruments/keysight/keysightN5767A.rst
@@ -1,5 +1,5 @@
 ########################
-keysight N5767A power supply
+Keysight N5767A power supply
 ########################
 
 .. autoclass:: pymeasure.instruments.keysight.KeysightN5767A

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -1,0 +1,1 @@
+from .keysightN57xxA import KeysightN57xxA

--- a/pymeasure/instruments/keysight/__init__.py
+++ b/pymeasure/instruments/keysight/__init__.py
@@ -1,1 +1,1 @@
-from .keysightN57xxA import KeysightN57xxA
+from .keysightN5767A import KeysightN5767A

--- a/pymeasure/instruments/keysight/keysightN5767A.py
+++ b/pymeasure/instruments/keysight/keysightN5767A.py
@@ -24,16 +24,16 @@
 
 
 import logging
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.validators import (
-    truncated_range, truncated_discrete_set,
-    strict_discrete_set
-)
+from pymeasure.instruments.validators import truncated_range
+
 
 from pymeasure.adapters import VISAAdapter
+
 
 class KeysightN5767A(Instrument):
     """ Represents the Keysight N5767A Power supply
@@ -56,7 +56,7 @@ class KeysightN5767A(Instrument):
 
     current = Instrument.measurement(":MEAS:CURR?",
         """ Reads a setting current in Amps. """
-    )
+     )
 
     ###############
     # Voltage (V) #
@@ -74,16 +74,27 @@ class KeysightN5767A(Instrument):
         """ Reads a DC voltage measurement in Volts. """
      )
 
-    ###############
-    # State (OFF/ON) #
-    ###############
-    state = Instrument.control(
-        ":OUTP?", ":OUTP %s",
-        """ Power supply output state, it can be set ON or OFF. """,
-        validator= strict_discrete_set,
-        values=['ON', 'OFF']
+    ##############
+    #_status (0/1) #
+    ##############
+    _status = Instrument.measurement(":OUTP?",
+        """ Read power supply current output status. """,
     )
 
+    def enable(self):
+        """ Enables the flow of current.
+        """
+        self.write(":OUTP 1")
+
+    def disable(self):
+        """ Disables the flow of current.
+        """
+        self.write(":OUTP 0")
+
+    def is_enabled(self):
+        """ Returns True if the current supply is enabled.
+        """
+        return bool(self._status)
 
     def __init__(self, adapter, **kwargs):
         super(KeysightN5767A, self).__init__(
@@ -98,7 +109,6 @@ class KeysightN5767A(Instrument):
                 separator=','
             )
 
-    # TODO: Clean up error checking
     def check_errors(self):
         """ Read all errors from the instrument."""
         while True:
@@ -108,4 +118,3 @@ class KeysightN5767A(Instrument):
                 log.error(errmsg + '\n')
             else:
                 break
-

--- a/pymeasure/instruments/keysight/keysightN5767A.py
+++ b/pymeasure/instruments/keysight/keysightN5767A.py
@@ -35,8 +35,8 @@ from pymeasure.instruments.validators import (
 
 from pymeasure.adapters import VISAAdapter
 
-class KeysightN57xxA(Instrument):
-    """ Represents the Keysight N57xxA series Power supply
+class KeysightN5767A(Instrument):
+    """ Represents the Keysight N5767A Power supply
     interface for interacting with the instrument.
 
     .. code-block:: python
@@ -48,10 +48,10 @@ class KeysightN57xxA(Instrument):
     current_range = Instrument.control(
         ":CURR?", ":CURR %g",
         """ A floating point property that controls the DC current range in
-        Amps, which can take values from 0 to 20 A.
+        Amps, which can take values from 0 to 25 A.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[0, 20],
+        values=[0, 25],
     )
 
     current = Instrument.measurement(":MEAS:CURR?",
@@ -64,10 +64,10 @@ class KeysightN57xxA(Instrument):
     voltage_range = Instrument.control(
         ":VOLT?", ":VOLT %g V",
         """ A floating point property that controls the DC voltage range in
-        Volts, which can take values from 0 to 100 V.
+        Volts, which can take values from 0 to 60 V.
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
-        values=[0, 100]
+        values=[0, 60]
     )
 
     voltage = Instrument.measurement("MEAS:VOLT?",
@@ -75,21 +75,19 @@ class KeysightN57xxA(Instrument):
      )
 
     ###############
-    # State (V) #
+    # State (OFF/ON) #
     ###############
     state = Instrument.control(
         ":OUTP?", ":OUTP %s",
-        """ A floating point property that controls the DC voltage range in
-        Volts, which can take values from 0 to 100 V.
-        Auto-range is disabled when this property is set. """,
+        """ Power supply output state, it can be set ON or OFF. """,
         validator= strict_discrete_set,
         values=['ON', 'OFF']
     )
 
 
     def __init__(self, adapter, **kwargs):
-        super(KeysightN57xxA, self).__init__(
-            adapter, "Keysight N57XXA power supply", **kwargs
+        super(KeysightN5767A, self).__init__(
+            adapter, "Keysight N5767A power supply", **kwargs
         )
         # Set up data transfer format
         if isinstance(self.adapter, VISAAdapter):
@@ -106,7 +104,7 @@ class KeysightN57xxA(Instrument):
         while True:
             err = self.values(":SYST:ERR?")
             if int(err[0]) != 0:
-                errmsg = "Keysight N57XXA: %s: %s" % (err[0],err[1])
+                errmsg = "Keysight N5767A: %s: %s" % (err[0],err[1])
                 log.error(errmsg + '\n')
             else:
                 break

--- a/pymeasure/instruments/keysight/keysightN57xxA.py
+++ b/pymeasure/instruments/keysight/keysightN57xxA.py
@@ -1,0 +1,113 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import (
+    truncated_range, truncated_discrete_set,
+    strict_discrete_set
+)
+
+from pymeasure.adapters import VISAAdapter
+
+class KeysightN57xxA(Instrument):
+    """ Represents the Keysight N57xxA series Power supply
+    interface for interacting with the instrument.
+
+    .. code-block:: python
+
+    """
+    ###############
+    # Current (A) #
+    ###############
+    current_range = Instrument.control(
+        ":CURR?", ":CURR %g",
+        """ A floating point property that controls the DC current range in
+        Amps, which can take values from 0 to 20 A.
+        Auto-range is disabled when this property is set. """,
+        validator=truncated_range,
+        values=[0, 20],
+    )
+
+    current = Instrument.measurement(":MEAS:CURR?",
+        """ Reads a setting current in Amps. """
+    )
+
+    ###############
+    # Voltage (V) #
+    ###############
+    voltage_range = Instrument.control(
+        ":VOLT?", ":VOLT %g V",
+        """ A floating point property that controls the DC voltage range in
+        Volts, which can take values from 0 to 100 V.
+        Auto-range is disabled when this property is set. """,
+        validator=truncated_range,
+        values=[0, 100]
+    )
+
+    voltage = Instrument.measurement("MEAS:VOLT?",
+        """ Reads a DC voltage measurement in Volts. """
+     )
+
+    ###############
+    # State (V) #
+    ###############
+    state = Instrument.control(
+        ":OUTP?", ":OUTP %s",
+        """ A floating point property that controls the DC voltage range in
+        Volts, which can take values from 0 to 100 V.
+        Auto-range is disabled when this property is set. """,
+        validator= strict_discrete_set,
+        values=['ON', 'OFF']
+    )
+
+
+    def __init__(self, adapter, **kwargs):
+        super(KeysightN57xxA, self).__init__(
+            adapter, "Keysight N57XXA power supply", **kwargs
+        )
+        # Set up data transfer format
+        if isinstance(self.adapter, VISAAdapter):
+            self.adapter.config(
+                is_binary=False,
+                datatype='float32',
+                converter='f',
+                separator=','
+            )
+
+    # TODO: Clean up error checking
+    def check_errors(self):
+        """ Read all errors from the instrument."""
+        while True:
+            err = self.values(":SYST:ERR?")
+            if int(err[0]) != 0:
+                errmsg = "Keysight N57XXA: %s: %s" % (err[0],err[1])
+                log.error(errmsg + '\n')
+            else:
+                break
+


### PR DESCRIPTION
Add keysight instruments N57xxA series power supply, including basic function such as  current/voltage and range, switch state

Signed-off-by: sumatrae <676119192@qq.com>