### PR TITLE
Prologix / Keithley2400 bug fixes

### DIFF
--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -104,7 +104,7 @@ class PrologixAdapter(SerialAdapter):
 
         :returns: String ASCII response of the instrument
         """
-        self.write("++read")
+        self.write("++read eoi")
         return b"\n".join(self.connection.readlines()).decode()
 
     def gpib(self, address, rw_delay=None):

--- a/pymeasure/adapters/prologix.py
+++ b/pymeasure/adapters/prologix.py
@@ -61,8 +61,8 @@ class PrologixAdapter(SerialAdapter):
 
     """
 
-    def __init__(self, port, address=None, rw_delay=None, **kwargs):
-        super().__init__(port, timeout=0.5, **kwargs)
+    def __init__(self, port, address=None, rw_delay=None, serial_timeout = 0.5, **kwargs):
+        super().__init__(port, timeout = serial_timeout, **kwargs)
         self.address = address
         self.rw_delay = rw_delay
         if not isinstance(port, serial.Serial):

--- a/pymeasure/instruments/keithley/buffer.py
+++ b/pymeasure/instruments/keithley/buffer.py
@@ -87,7 +87,7 @@ class KeithleyBuffer(object):
             sleep(interval)
             if should_stop():
                 return
-            if (time()-t)>10:
+            if (time()-t)>timeout:
                 raise Exception("Timed out waiting for Keithley buffer to fill.")
 
     @property


### PR DESCRIPTION
While debugging the connection to my Keithley2400 through a Prologix Adapter, I found it useful to be able to select the serial timeout manually. This would imply a very simple change in the `__init__` of PrologixAdapter as such:

```
    def __init__(self, port, address=None, rw_delay=None, serial_timeout = 0.5, **kwargs):
        super().__init__(port, timeout = serial_timeout, **kwargs)
```

instead of the current code that has a hardcoded value of 0.5s
```
    def __init__(self, port, address=None, rw_delay=None, **kwargs):
        super().__init__(port, timeout = 0.5, **kwargs)
```