### PR TITLE
Delta elektronica power supply sm70-45D

### DIFF
--- a/docs/api/instruments/deltaelektronica/index.rst
+++ b/docs/api/instruments/deltaelektronica/index.rst
@@ -1,0 +1,12 @@
+.. module:: pymeasure.instruments.deltaelektronika
+
+#########
+Delta Elektronika
+#########
+
+This section contains specific documentation on the Delta Elektronika instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   sm7045d

--- a/docs/api/instruments/deltaelektronica/sm7045d.rst
+++ b/docs/api/instruments/deltaelektronica/sm7045d.rst
@@ -1,0 +1,7 @@
+##################################
+Delta Elektronica SM7045D Power source
+##################################
+
+.. autoclass:: pymeasure.instruments.deltaelektronika.SM7045D
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -32,6 +32,7 @@ from . import advantest
 from . import agilent
 from . import ametek
 from . import anritsu
+from . import deltaelektronika
 from . import danfysik
 from . import fwbell
 from . import hp

--- a/pymeasure/instruments/deltaelektronika/__init__.py
+++ b/pymeasure/instruments/deltaelektronika/__init__.py
@@ -1,0 +1,25 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from .sm7045d import SM7045D

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -30,7 +30,17 @@ import numpy as np
 
 
 class SM7045D(Instrument):
-    """ This is the class for the SM 70-45 D power supply """
+    """ This is the class for the SM 70-45 D power supply.
+
+    .. code-block:: python
+
+        source = SM7045D("GPIB::8")
+
+        source.ramp_to_zero(1)               # Set output to 0 before enabling
+        source.enable()                      # Enables the output
+        source.current = 1                   # Sets a current of 1 Amps
+
+    """
     VOLTAGE_RANGE = [0, 70]
     CURRENT_RANGE = [0, 45]
 
@@ -74,7 +84,8 @@ class SM7045D(Instrument):
 
     measure_current = Instrument.measurement(
         "ME:CU?",
-        """ Measures the actual output current of the power supply in Amps. """,
+        """ Measures the actual output current of the power supply in
+        Amps. """,
     )
 
     rsd = Instrument.measurement(

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -23,6 +23,7 @@
 #
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_range
 
 from time import sleep
 import numpy as np
@@ -30,46 +31,56 @@ import numpy as np
 
 class SM7045D(Instrument):
     """ This is the class for the SM 70-45 D power supply """
+    VOLTAGE_RANGE = [0, 70]
+    CURRENT_RANGE = [0, 45]
 
     voltage = Instrument.control(
         "SO:VO?", "SO:VO %g",
         """ A floating point property that represents the output voltage
-        setting of the power supply in Volts. This property can be set. """
+        setting of the power supply in Volts. This property can be set. """,
+        validator=strict_range,
+        values=VOLTAGE_RANGE
     )
 
     current = Instrument.control(
         "SO:CU?", "SO:CU %g",
         """ A floating point property that represents the output current of
-        the power supply in Amps. This property can be set. """
+        the power supply in Amps. This property can be set. """,
+        validator=strict_range,
+        values=CURRENT_RANGE
     )
 
     max_voltage = Instrument.control(
         "SO:VO:MA?", "SO:VO:MA %g",
         """ A floating point property that represents the maximum output
-        voltage of the power supply in Volts. This property can be set. """
+        voltage of the power supply in Volts. This property can be set. """,
+        validator=strict_range,
+        values=VOLTAGE_RANGE
     )
 
     max_current = Instrument.control(
         "SO:CU:MA?", "SO:VO:MA %g",
         """ A floating point property that represents the maximum output
-        current of the power supply in Amps. This property can be set. """
+        current of the power supply in Amps. This property can be set. """,
+        validator=strict_range,
+        values=CURRENT_RANGE
     )
 
     measure_voltage = Instrument.measurement(
         "ME:VO?",
         """ Measures the actual output voltage of the power supply in
-        Volts. """
+        Volts. """,
     )
 
     measure_current = Instrument.measurement(
         "ME:CU?",
-        """ Measures the actual output current of the power supply in Amps. """
+        """ Measures the actual output current of the power supply in Amps. """,
     )
 
     rsd = Instrument.measurement(
         "SO:FU:RSD?",
         """ Check whether remote shutdown is enabled/disabled and thus if the
-        output of the power supply is disabled/enabled. """
+        output of the power supply is disabled/enabled. """,
     )
 
     def __init__(self, resourceName, **kwargs):

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -1,0 +1,103 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2017 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument
+
+from time import sleep
+import numpy as np
+
+
+class SM7045D(Instrument):
+    """ This is the class for the SM 70-45 D power supply """
+
+    voltage = Instrument.control(
+        "SO:VO?", "SO:VO %g",
+        """ A floating point property that represents the output voltage
+        setting of the power supply in Volts. This property can be set. """
+    )
+
+    current = Instrument.control(
+        "SO:CU?", "SO:CU %g",
+        """ A floating point property that represents the output current of
+        the power supply in Amps. This property can be set. """
+    )
+
+    max_voltage = Instrument.control(
+        "SO:VO:MA?", "SO:VO:MA %g",
+        """ A floating point property that represents the maximum output
+        voltage of the power supply in Volts. This property can be set. """
+    )
+
+    max_current = Instrument.control(
+        "SO:CU:MA?", "SO:VO:MA %g",
+        """ A floating point property that represents the maximum output
+        current of the power supply in Amps. This property can be set. """
+    )
+
+    measure_voltage = Instrument.measurement(
+        "ME:VO?",
+        """ Measures the actual output voltage of the power supply in
+        Volts. """
+    )
+
+    measure_current = Instrument.measurement(
+        "ME:CU?",
+        """ Measures the actual output current of the power supply in Amps. """
+    )
+
+    rsd = Instrument.measurement(
+        "SO:FU:RSD?",
+        """ Check whether remote shutdown is enabled/disabled and thus if the
+        output of the power supply is disabled/enabled. """
+    )
+
+    def __init__(self, resourceName, **kwargs):
+        super(SM7045D, self).__init__(
+            resourceName,
+            "Delta Elektronika SM 70-45 D",
+            **kwargs
+        )
+
+    def enable(self):
+        # Disable remote shutdown, hence output will be enabled.
+        self.write("SO:FU:RSD 0")
+
+    def disable(self):
+        # Enables remote shutdown, hence input will be disabled.
+        self.write("SO:FU:RSD 1")
+
+    def ramp_to_current(self, target_current, current_step):
+        # Gradually increase/decrease current to target current.
+        curr = self.current
+        n = round(abs(curr - target_current) / current_step) + 1
+        for i in np.linspace(curr, target_current, n):
+            self.current = i
+            sleep(0.1)
+
+    def ramp_to_zero(self, current_step):
+        self.ramp_to_current(0, current_step)
+
+    def shutdown(self, actual_current):
+        self.ramp_to_zero()
+        self.disable()

--- a/pymeasure/instruments/deltaelektronika/sm7045d.py
+++ b/pymeasure/instruments/deltaelektronika/sm7045d.py
@@ -26,7 +26,7 @@ from pymeasure.instruments import Instrument
 from pymeasure.instruments.validators import strict_range
 
 from time import sleep
-import numpy as np
+from numpy import linspace
 
 
 class SM7045D(Instrument):
@@ -102,24 +102,45 @@ class SM7045D(Instrument):
         )
 
     def enable(self):
-        # Disable remote shutdown, hence output will be enabled.
+        """
+        Disable remote shutdown, hence output will be enabled.
+        """
         self.write("SO:FU:RSD 0")
 
     def disable(self):
-        # Enables remote shutdown, hence input will be disabled.
+        """
+        Enables remote shutdown, hence input will be disabled.
+        """
         self.write("SO:FU:RSD 1")
 
-    def ramp_to_current(self, target_current, current_step):
-        # Gradually increase/decrease current to target current.
+    def ramp_to_current(self, target_current, current_step=0.1):
+        """
+        Gradually increase/decrease current to target current.
+
+        :param target_current: Float that sets the target current (in A)
+        :param current_step: Optional float that sets the current steps
+                             / ramp rate (in A/s)
+        """
+
         curr = self.current
         n = round(abs(curr - target_current) / current_step) + 1
-        for i in np.linspace(curr, target_current, n):
+        for i in linspace(curr, target_current, n):
             self.current = i
             sleep(0.1)
 
-    def ramp_to_zero(self, current_step):
+    def ramp_to_zero(self, current_step=0.1):
+        """
+        Gradually decrease the current to zero.
+
+        :param current_step: Optional float that sets the current steps
+                             / ramp rate (in A/s)
+        """
+
         self.ramp_to_current(0, current_step)
 
-    def shutdown(self, actual_current):
+    def shutdown(self):
+        """
+        Set the current to 0 A and disable the output of the power source.
+        """
         self.ramp_to_zero()
         self.disable()


### PR DESCRIPTION
**Ready for merging**

Added support for the Delta Elektronika SM70-45D Power supply (serves also as an example for other power supplies of Delta Elektronika as they use the same communication)