### PR TITLE
Readthedocs update

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,8 +3,8 @@ formats:
         - pdf
 
 conda:
-    file: requirements/conda-3.5.yml
+    file: requirements/conda-3.6.yml
 
 python:
-   version: 3
+   version: 3.6
    setup_py_install: true


### PR DESCRIPTION
This PR updates the configuration for Readthedocs, so that it uses Python 3.6. The latest build has failed due to a `sphinx` issue that appears to be limited to Python 3.5.