### PR TITLE
Relax version specifiers for tests.

### DIFF
--- a/requirements/conda-3.4.yml
+++ b/requirements/conda-3.4.yml
@@ -20,4 +20,4 @@ dependencies:
 - wheel=0.29.0=py34_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/requirements/conda-3.5.yml
+++ b/requirements/conda-3.5.yml
@@ -17,4 +17,4 @@ dependencies:
 - wheel=0.29.0=py35_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -17,4 +17,4 @@ dependencies:
 - wheel=0.29.0=py36_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
         'pytest-runner'
     ],
     tests_require=[
-        'pytest == 4.4.1',
-        'pytest-qt == 3.2.2'
+        'pytest >= 2.9.1',
+        'pytest-qt >= 2.4.0'
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Using pytest >=4.1 and pytest-qt <2.4.0 at the same time caused [problems with CI](https://travis-ci.org/ralph-group/pymeasure/builds/522777460). 
This change constrains the requirements to a minimum/flexible configuration and avoids pinned versions.

[This commit](https://github.com/pytest-dev/pytest-qt/commit/922b73b9f5d8e0930ef47683c8e0771780f75333) (released in pytest-qt 2.4.0) introduced some fixes for pytest 3.6+ compatibility (deprecation of pytest's `get_marker` and removal in pytest 4, which caused the error we saw), but in CI we used only 2.2.1, therefore with pytest 4+, there was an incompatibility. 
While strictly pinned versions solve this specific problem by avoiding the broken version set, it will probably cause further problems down the line for people not being able to fulfill the strict requirements (e.g. by two libraries pinning to two different pytest versions). A version constraint that is only as strict as necessary is generally preferable, and is proposed here.

By the way, [this line](https://travis-ci.org/ralph-group/pymeasure/jobs/522777463#L624) shows how in the `pip` section of the requirements.yml, current pytest 4 gets dragged in (which actually surfaced this problem) despite 3.1.1 being specified and installed in the conda install step. That pip installs dependencies greedily is an interesting detail of requirements files to be aware of. In light of this, maybe it's worth it to keep one parallel build on more recent versions (instead of hard-pinning with requirements.yml), to be able to gracefully deal with changes in our dependencies?