### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -265,7 +265,7 @@ class ScientificInput(QtGui.QDoubleSpinBox, Input):
 
     def textFromValue(self, value):
         string = "{:g}".format(value).replace("e+", "e")
-        string = re.sub("e(-?)0*(\d+)", r"e\1\2", string)
+        string = re.sub(r"e(-?)0*(\d+)", r"e\1\2", string)
         return string
 
     def stepEnabled(self):

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -107,12 +107,12 @@ class PlotFrame(QtGui.QFrame):
     def parse_axis(self, axis):
         """ Returns the units of an axis by searching the string
         """
-        units_pattern = "\((?P<units>\w+)\)"
+        units_pattern = r"\((?P<units>\w+)\)"
         try:
             match = re.search(units_pattern, axis)
         except TypeError:
             match = None
-            
+
         if match:
             if 'units' in match.groupdict():
                 label = re.sub(units_pattern, '', axis)

--- a/pymeasure/experiment/results.py
+++ b/pymeasure/experiment/results.py
@@ -229,13 +229,13 @@ class Results(object):
                 raise ValueError("Parsing a header which contains "
                                  "uncommented sections")
             if line.startswith("Procedure"):
-                regex = "<(?:(?P<module>[^>]+)\.)?(?P<class>[^.>]+)>"
+                regex = r"<(?:(?P<module>[^>]+)\.)?(?P<class>[^.>]+)>"
                 search = re.search(regex, line)
                 procedure_module = search.group("module")
                 procedure_class = search.group("class")
             elif line.startswith("\t"):
-                regex = ("\t(?P<name>[^:]+):\s(?P<value>[^\s]+)"
-                         "(?:\s(?P<units>.+))?")
+                regex = (r"\t(?P<name>[^:]+):\s(?P<value>[^\s]+)"
+                         r"(?:\s(?P<units>.+))?")
                 search = re.search(regex, line)
                 if search is None:
                     raise Exception("Error parsing header line %s." % line)

--- a/pymeasure/instruments/anritsu/anritsuMS9710C.py
+++ b/pymeasure/instruments/anritsu/anritsuMS9710C.py
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 # Analysis Results with Units, ie -24.5DBM -> (-24.5, 'DBM')
-r_value_units = re.compile("([-\d]*\.\d*)(.*)")
+r_value_units = re.compile(r"([-\d]*\.\d*)(.*)")
 
 # Join validators to allow for special sets of characters
 truncated_range_or_off = joined_validators(strict_discrete_set, truncated_range)

--- a/pymeasure/instruments/danfysik/adapters.py
+++ b/pymeasure/instruments/danfysik/adapters.py
@@ -41,8 +41,8 @@ class DanfysikAdapter(SerialAdapter):
         super(DanfysikAdapter, self).__init__(port, baudrate=9600, timeout=0.5)
 
     def write(self, command):
-        """ Overwrites the :func:`SerialAdapter.write <pymeasure.adapters.SerialAdapter.write>` 
-        method to automatically append a Unix-style linebreak at 
+        """ Overwrites the :func:`SerialAdapter.write <pymeasure.adapters.SerialAdapter.write>`
+        method to automatically append a Unix-style linebreak at
         the end of the command.
 
         :param command: SCPI command string to be sent to the instrument
@@ -51,9 +51,9 @@ class DanfysikAdapter(SerialAdapter):
         self.connection.write(command.encode())
 
     def read(self):
-        """ Overwrites the :func:`SerialAdapter.read <pymeasure.adapters.Adapter.read>` 
+        """ Overwrites the :func:`SerialAdapter.read <pymeasure.adapters.Adapter.read>`
         method to automatically raise exceptions if errors are reported by the instrument.
-        
+
         :returns: String ASCII response of the instrument
         :raises: An :code:`Exception` if the Danfysik raises an error
         """
@@ -61,7 +61,7 @@ class DanfysikAdapter(SerialAdapter):
         result = b"".join(self.connection.readlines())
         result = result.decode()
         result = result.replace("\r", "")
-        search = re.search("^\?\\x07\s(?P<name>.*)$", result, re.MULTILINE)
+        search = re.search(r"^\?\x07\s(?P<name>.*)$", result, re.MULTILINE)
         if search:
             raise Exception("Danfysik raised the error: %s" % (
                             search.groups()[0]))

--- a/pymeasure/instruments/yokogawa/yokogawa7651.py
+++ b/pymeasure/instruments/yokogawa/yokogawa7651.py
@@ -64,8 +64,8 @@ class Yokogawa7651(Instrument):
         called directly by the user.
         """
         status = ''.join(v.split("\r\n\n")[1:-1])
-        keys = re.findall('[^\dE+.-]+', status)
-        values = re.findall('[\dE+.-]+', status)
+        keys = re.findall(r'[^\dE+.-]+', status)
+        values = re.findall(r'[\dE+.-]+', status)
         if key not in keys:
             raise ValueError("Invalid key used to search for status of Yokogawa 7561")
         else:
@@ -134,17 +134,17 @@ class Yokogawa7651(Instrument):
         super(Yokogawa7651, self).__init__(
             adapter, "Yokogawa 7651 Programmable DC Source", **kwargs
         )
-        
+
         self.write("H0;E") # Set no header in output data
-        
+
     @property
     def id(self):
         """ Returns the identification of the instrument """
         return self.ask("OS;E").split('\r\n\n')[0]
-        
+
     @property
     def source_enabled(self):
-        """ Reads a boolean value that is True if the source is enabled, 
+        """ Reads a boolean value that is True if the source is enabled,
         determined by checking if the 5th bit of the OC flag is a binary 1.
         """
         oc = int(self.ask("OC;E")[5:])
@@ -159,7 +159,7 @@ class Yokogawa7651(Instrument):
         """ Disables the source of current or voltage depending on the
         configuration of the instrument. """
         self.write("O0;E")
-        
+
     def apply_current(self, max_current=1e-3, complinance_voltage=1):
         """ Configures the instrument to apply a source current, which can
         take optional parameters that defer to the :attr:`~.Yokogawa7651.source_current_range`

--- a/requirements/conda-3.4.yml
+++ b/requirements/conda-3.4.yml
@@ -20,4 +20,4 @@ dependencies:
 - wheel=0.29.0=py34_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/requirements/conda-3.5.yml
+++ b/requirements/conda-3.5.yml
@@ -17,4 +17,4 @@ dependencies:
 - wheel=0.29.0=py35_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -17,4 +17,4 @@ dependencies:
 - wheel=0.29.0=py36_0
 - pip:
   - pyvisa==1.8
-  - pytest-qt==2.2.1
+  - pytest-qt==2.4.0

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
         'pytest-runner'
     ],
     tests_require=[
-        'pytest == 4.4.1',
-        'pytest-qt == 3.2.2'
+        'pytest >= 2.9.1',
+        'pytest-qt >= 2.4.0'
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,3 @@
 #
 
 import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption("--runslow", action="store_true",
-                     help="run slow tests")

--- a/tests/experiment/test_workers.py
+++ b/tests/experiment/test_workers.py
@@ -37,12 +37,6 @@ RandomProcedure = SourceFileLoader('procedure', data_path).load_module().RandomP
 #from data.procedure_for_testing import RandomProcedure
 
 
-slow = pytest.mark.skipif(
-    not pytest.config.getoption("--runslow"),
-    reason="need --runslow option to run"
-)
-
-
 def test_procedure():
     """ Ensure that the loaded test procedure is properly functioning
     """


### PR DESCRIPTION
This fixes various [DeprecationWarnings](https://travis-ci.org/ralph-group/pymeasure/jobs/523174766#L768-L810) caused by using regex with non-raw strings.

I also propose (for you to decide) to remove the unused --runslow argument to pytest, as it uses a deprecated pytest API:

>  /home/travis/build/ralph-group/pymeasure/tests/experiment/test_workers.py:41: PytestDeprecationWarning: the `pytest.config` global is deprecated.  Please use `request.config` or `pytest_configure` (if you're a pytest plugin) instead.
    not pytest.config.getoption("--runslow"),

If needed can easily be put back [according to the pytest docs](https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option).

Note that to have a passing CI, this PR also includes the changes from #191.

