### PR TITLE
Use conda-forge instead of pip packages in CI.

### DIFF
--- a/requirements/conda-3.4.yml
+++ b/requirements/conda-3.4.yml
@@ -18,6 +18,5 @@ dependencies:
 - sip=4.18=py34_0
 - six=1.10.0=py34_0
 - wheel=0.29.0=py34_0
-- pip:
-  - pyvisa==1.8
-  - pytest-qt==2.4.0
+- pyvisa==1.8
+- pytest-qt==2.4.0

--- a/requirements/conda-3.5.yml
+++ b/requirements/conda-3.5.yml
@@ -1,4 +1,7 @@
 name: pymeasure
+channels:
+- conda-forge
+- defaults
 dependencies:
 - numpy=1.11.0=py35_1
 - pandas=0.18.1=np111py35_0
@@ -15,6 +18,5 @@ dependencies:
 - sip=4.18=py35_0
 - six=1.10.0=py35_0
 - wheel=0.29.0=py35_0
-- pip:
-  - pyvisa==1.8
-  - pytest-qt==2.4.0
+- pyvisa==1.8
+- pytest-qt==2.4.0

--- a/requirements/conda-3.6.yml
+++ b/requirements/conda-3.6.yml
@@ -1,4 +1,7 @@
 name: pymeasure
+channels:
+- conda-forge
+- defaults
 dependencies:
 - numpy=1.12.1=py36_0
 - pandas=0.19.2=np112py36_1
@@ -15,6 +18,5 @@ dependencies:
 - sip=4.18=py36_0
 - six=1.10.0=py36_0
 - wheel=0.29.0=py36_0
-- pip:
-  - pyvisa==1.8
-  - pytest-qt==2.4.0
+- pyvisa==1.8
+- pytest-qt==2.4.0


### PR DESCRIPTION
This should make sure that we really use the pytest version specified.