### PR TITLE
Fix for issue ResultsDialog

### DIFF
--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -361,6 +361,7 @@ class ResultsDialog(QtGui.QFileDialog):
         super().__init__(parent)
         self.columns = columns
         self.x_axis, self.y_axis = x_axis, y_axis
+        self.setOption(QtGui.QFileDialog.DontUseNativeDialog, True)
         self._setup_ui()
 
     def _setup_ui(self):


### PR DESCRIPTION
**Ready to be merged**

When using the open button in the manager window the following error message appears:
```
Traceback (most recent call last):
  File "d:\git\pymeasure\pymeasure\display\windows.py", line 325, in open_experiment
    dialog = ResultsDialog(self.procedure_class.DATA_COLUMNS, self.x_axis, self.y_axis)
  File "d:\git\pymeasure\pymeasure\display\widgets.py", line 364, in __init__
    self._setup_ui()
  File "d:\git\pymeasure\pymeasure\display\widgets.py", line 387, in _setup_ui
    self.layout().addWidget(preview_tab, 0, 5, 4, 1)
AttributeError: 'NoneType' object has no attribute 'addWidget'
```

This happens for PyQT version 5.9.2, but when reverting PyQT to 5.6.2 the same issue arrises (sometimes).
It seems to happen because PyQT decides to use the native file explorer for it's QFileDialog, while the ResultsDialog relies on the QT-based QFileDialog (as it tries to add a widget).

It can easily be solved by either not adding the preview pane to the QFileDialog, or (as done in this pull request) by enforcing PyQT to not use the native file explorer, thereby allowing to keep using the preview pane.