### PR TITLE
Fixing Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: xenial
       env: PYTHON=3.5  CONDA_PY=35
       sudo: true
-      serivces:
+      services:
         - xvfb
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,29 @@ language: c
 matrix:
   include:
     - os: linux
+      dist: xenial
       env: PYTHON=3.4  CONDA_PY=34
       sudo: true
+      services:
+        - xvfb
     - os: linux
+      dist: xenial
       env: PYTHON=3.5  CONDA_PY=35
       sudo: true
+      serivces:
+        - xvfb
     - os: linux
+      dist: xenial
       env: PYTHON=3.6  CONDA_PY=36
       sudo: true
+      services:
+        - xvfb
     - os: linux
+      dist: xenial
       env: PYTHON=3.6 DOCS=true
       sudo: true
+      services:
+        - xvfb
     - os: osx
       env: PYTHON=3.4  CONDA_PY=34
       sudo: false
@@ -50,13 +62,13 @@ install:
   - conda info -a
 
 # test environment setup
-before_script:
+#before_script:
   # GUI testing on Linux
-  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        export DISPLAY=:99.0;
-        sh -e /etc/init.d/xvfb start;
-        sleep 3;
-    fi'
+  #  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  #      export DISPLAY=:99.0;
+  #      sh -e /etc/init.d/xvfb start;
+  #      sleep 3;
+  #  fi'
 
 # command to run tests
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,15 +61,6 @@ install:
     fi
   - conda info -a
 
-# test environment setup
-#before_script:
-  # GUI testing on Linux
-  #  - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-  #      export DISPLAY=:99.0;
-  #      sh -e /etc/init.d/xvfb start;
-  #      sleep 3;
-  #  fi'
-
 # command to run tests
 script: 
   - python setup.py test


### PR DESCRIPTION
This PR fixes the Qt tests in Travis CI by ensuring that the Ubuntu Xenial distribution is used explicitly, and the xvfb (virtual frame buffer) service is enabled correctly.

https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui