### PR TITLE
Fixing conda tests on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,7 +66,7 @@ install:
   - conda update -q conda
   - conda info -a
   - "conda env create -f requirements/conda-%PYTHON_VERSION%.yml"
-  - conda activate pymeasure
+  - activate pymeasure
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,11 +61,12 @@ install:
   #- "%PYTHON%\\python.exe -m pip install -r requirements/core.txt"
 
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - call %MINICONDA%\Scripts\activate.bat
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
   - "conda env create -f requirements/conda-%PYTHON_VERSION%.yml"
-  - activate pymeasure
+  - conda activate pymeasure
 
 build: off
 


### PR DESCRIPTION
Currently the CI is failing on Appveyor for Python 3.7. This PR fixes the issue by ensuring that the activation script is correctly called.