### PR TITLE
add read_bytes method for VISA communication

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -87,11 +87,20 @@ class VISAAdapter(Adapter):
 
     def read(self):
         """ Reads until the buffer is empty and returns the resulting
-        ASCII respone
+        ASCII response
 
         :returns: String ASCII response of the instrument.
         """
         return self.connection.read()
+
+    def read_bytes(self, size):
+        """ Reads specified number of bytes from the buffer and returns
+        the resulting ASCII response
+
+        :param size: Number of bytes to read from the buffer
+        :returns: String ASCII response of the instrument.
+        """
+        return self.connection.read_bytes(size)
 
     def ask(self, command):
         """ Writes the command to the instrument and returns the resulting

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -104,6 +104,12 @@ class Instrument(object):
         """
         return self.adapter.read()
 
+    def read_bytes(self, size):
+        """ Reads specified number of bytes from the instrument through
+        the adapter and returns the response.
+        """
+        return self.adapter.read_bytes(size)
+
     def values(self, command, **kwargs):
         """ Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.


### PR DESCRIPTION
For some instruments it is handy to read a specified number of bytes from the data output buffer. This just passes the corresponding method of the underlying visa module all the way to the instrument level.

This is my first ever pull request, I hope to not not miss out on something...