### PR TITLE
add read_bytes method for VISA communication

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -87,11 +87,20 @@ class VISAAdapter(Adapter):
 
     def read(self):
         """ Reads until the buffer is empty and returns the resulting
-        ASCII respone
+        ASCII response
 
         :returns: String ASCII response of the instrument.
         """
         return self.connection.read()
+
+    def read_bytes(self, size):
+        """ Reads specified number of bytes from the buffer and returns
+        the resulting ASCII response
+
+        :param size: Number of bytes to read from the buffer
+        :returns: String ASCII response of the instrument.
+        """
+        return self.connection.read_bytes(size)
 
     def ask(self, command):
         """ Writes the command to the instrument and returns the resulting

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -104,6 +104,12 @@ class Instrument(object):
         """
         return self.adapter.read()
 
+    def read_bytes(self, size):
+        """ Reads specified number of bytes from the instrument through
+        the adapter and returns the response.
+        """
+        return self.adapter.read_bytes(size)
+
     def values(self, command, **kwargs):
         """ Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.

--- a/pymeasure/instruments/instrument.py
+++ b/pymeasure/instruments/instrument.py
@@ -104,12 +104,6 @@ class Instrument(object):
         """
         return self.adapter.read()
 
-    def read_bytes(self, size):
-        """ Reads specified number of bytes from the instrument through
-        the adapter and returns the response.
-        """
-        return self.adapter.read_bytes(size)
-
     def values(self, command, **kwargs):
         """ Reads a set of values from the instrument through the adapter,
         passing on any key-word arguments.


### PR DESCRIPTION
As discussed in previous #226, adding `read_bytes` to `Instrument` as well would break `Instrument` 's functionality when using adapters that do not support `read_bytes` method. Therefore just adding the `read_bytes` methods in the `visa` library.

If needed `read_bytes` can be accessed from a particular instrument via `self.adapter.read_bytes()` instead of the shorter `self.write()` etc.