### PR TITLE
ScientificInput: increase robustness against non-numeric values

### DIFF
--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -258,10 +258,13 @@ class ScientificInput(QtGui.QDoubleSpinBox, Input):
         self.lineEdit().setText(text.toLower())
 
     def valueFromText(self, text):
-        if self._parameter.units:
-            return float(str(text)[:-(len(self._parameter.units) + 1)])
-        else:
-            return float(str(text))
+        try:
+            if self._parameter.units:
+                return float(str(text)[:-(len(self._parameter.units) + 1)])
+            else:
+                return float(str(text))
+        except ValueError:
+            return self._parameter.default
 
     def textFromValue(self, value):
         string = "{:g}".format(value).replace("e+", "e")


### PR DESCRIPTION
When accidentally entering wrong values in a FloatParameter InputBox, e.g. a comma instead of a point as decimal separator, the whole GUI crashes due to a raised ValueError. Within ScientificInput the input string cannot be converted to a float.

This PR catches the exception when the entered value cannot be converted to float. The default value is returned and set instead.