### PR TITLE
Add validator for discrete range of values

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,4 +18,5 @@ Casper Schippers
 Sumatran Tiger
 Michael Schneider
 Dennis Feng
+Stefano Pirotta
 Moritz Jung

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -18,3 +18,4 @@ Casper Schippers
 Sumatran Tiger
 Michael Schneider
 Dennis Feng
+Moritz Jung

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -21,4 +21,5 @@ The following developers have contributed to the PyMeasure package:
 | Casper Schippers
 | Sumatran Tiger
 | Dennis Feng
+| Stefano Pirotta
 | Moritz Jung

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -21,3 +21,4 @@ The following developers have contributed to the PyMeasure package:
 | Casper Schippers
 | Sumatran Tiger
 | Dennis Feng
+| Moritz Jung

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -39,6 +39,29 @@ def strict_range(value, values):
             value, min(values), max(values)
         ))
 
+def strict_discrete_range(value, values, step):
+    """ Provides a validator function that returns the value
+    if its value is less than the maximum and greater than the
+    minimum of the range and is a multiple of step. 
+    Otherwise it raises a ValueError.
+
+    :param value: A value to test
+    :param values: A range of values (range, list, etc.)
+    :param step: Minimum stepsize (resolution limit)
+    :raises: ValueError if the value is out of the range
+    """
+    if (min(values) <= value <= max(values)): 
+        if (value/step).is_integer():
+            return value
+        else:
+            raise ValueError('Value of {:g} is not a multiple of {:g}'.format(
+                value, step
+            ))
+    else:
+        raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
+            value, min(values), max(values)
+        ))
+
 
 def strict_discrete_set(value, values):
     """ Provides a validator function that returns the value

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -22,6 +22,8 @@
 # THE SOFTWARE.
 #
 
+from decimal import Decimal
+
 
 def strict_range(value, values):
     """ Provides a validator function that returns the value
@@ -51,16 +53,14 @@ def strict_discrete_range(value, values, step):
     :param step: Minimum stepsize (resolution limit)
     :raises: ValueError if the value is out of the range
     """
-    if (min(values) <= value <= max(values)):
-        if (value/step).is_integer():
-            return value
-        else:
-            raise ValueError('Value of {:g} is not a multiple of {:g}'.format(
-                value, step
-            ))
+    # use Decimal type to provide correct decimal compatible floating
+    # point arithmetic compared to binary floating point arithmetic
+    if (strict_range(value, values) == value and
+            Decimal(str(value)) % Decimal(str(step)) == 0):
+        return value
     else:
-        raise ValueError('Value of {:g} is not in range [{:g},{:g}]'.format(
-            value, min(values), max(values)
+        raise ValueError('Value of {:g} is not a multiple of {:g}'.format(
+            value, step
         ))
 
 

--- a/pymeasure/instruments/validators.py
+++ b/pymeasure/instruments/validators.py
@@ -39,10 +39,11 @@ def strict_range(value, values):
             value, min(values), max(values)
         ))
 
+
 def strict_discrete_range(value, values, step):
     """ Provides a validator function that returns the value
     if its value is less than the maximum and greater than the
-    minimum of the range and is a multiple of step. 
+    minimum of the range and is a multiple of step.
     Otherwise it raises a ValueError.
 
     :param value: A value to test
@@ -50,7 +51,7 @@ def strict_discrete_range(value, values, step):
     :param step: Minimum stepsize (resolution limit)
     :raises: ValueError if the value is out of the range
     """
-    if (min(values) <= value <= max(values)): 
+    if (min(values) <= value <= max(values)):
         if (value/step).is_integer():
             return value
         else:
@@ -139,7 +140,8 @@ def truncated_discrete_set(value, values):
 
 
 def joined_validators(*validators):
-    """ Join a list of validators together as a single.  Expects a list of validator functions and values.
+    """ Join a list of validators together as a single.
+    Expects a list of validator functions and values.
 
     :param validators: an iterable of other validators
     """

--- a/tests/instruments/test_validators.py
+++ b/tests/instruments/test_validators.py
@@ -24,7 +24,7 @@
 
 import pytest
 from pymeasure.instruments.validators import (
-    strict_range, strict_discrete_set,
+    strict_range, strict_discrete_range, strict_discrete_set,
     truncated_range, truncated_discrete_set,
     modular_range, modular_range_bidirectional,
     joined_validators
@@ -36,6 +36,20 @@ def test_strict_range():
     assert strict_range(5.1, range(10)) == 5.1
     with pytest.raises(ValueError) as e_info:
         strict_range(20, range(10))
+
+
+def test_strict_discrete_range():
+    assert strict_discrete_range(0.1, [0, 0.2], 0.001) == 0.1
+    assert strict_discrete_range(5, range(10), 0.1) == 5
+    assert strict_discrete_range(5.1, range(10), 0.1) == 5.1
+    assert strict_discrete_range(5.1, range(10), 0.001) == 5.1
+    assert strict_discrete_range(-5.1, [-20, 20], 0.001) == -5.1
+    with pytest.raises(ValueError) as e_info:
+        strict_discrete_range(5.1, range(5), 0.001)
+    with pytest.raises(ValueError) as e_info:
+        strict_discrete_range(5.01, range(5), 0.1)
+    with pytest.raises(ValueError) as e_info:
+        strict_discrete_range(0.003, [0, 0.2], 0.002)
 
 
 def test_strict_discrete_set():
@@ -58,6 +72,7 @@ def test_truncated_discrete_set():
     assert truncated_discrete_set(5.1, range(10)) == 6
     assert truncated_discrete_set(11, range(10)) == 9
     assert truncated_discrete_set(-10, range(10)) == 0
+
 
 def test_modular_range():
     assert modular_range(5, range(10)) == 5


### PR DESCRIPTION
Add validator to check if value is within a range of values and is a multiple of a given stepsize. This is useful for values which have a resolution limit. 
E.g. setting a sampling interval to 0.015s is allowed for a range of 0.01s to 2s. But if the maximum resolution of the instrument is 0.1s, it makes no sense to "pretend" higher accuracy in setting the value. This validator checks if the given value is a multiple of the resolution value or stepsize given.