### PR TITLE
Ensuring that the Recorder thread is joined properly on Worker.shutdown

### DIFF
--- a/pymeasure/experiment/workers.py
+++ b/pymeasure/experiment/workers.py
@@ -123,7 +123,7 @@ class Worker(StoppableThread):
             self.update_status(Procedure.FINISHED)
             self.emit('progress', 100.)
 
-        self.recorder.enqueue_sentinel()
+        self.recorder.stop()
         self.monitor_queue.put(None)
 
     def run(self):

--- a/tests/experiment/test_workers.py
+++ b/tests/experiment/test_workers.py
@@ -65,5 +65,7 @@ def test_worker_finish():
     worker.start()
     worker.join(timeout=5)
 
+    assert not worker.is_alive()
+
     new_results = Results.load(file, procedure_class=RandomProcedure)
     assert new_results.data.shape == (100, 2)


### PR DESCRIPTION
This PR ensures that the `Recorder` thread is joined properly during `Worker.shutdown`. In #235 on Windows, this appears to cause the file handle to be left open.

Previously, we used the `enqueue_sentinel` method to tell the `Recorder` to stop. This is called within the `stop` method, with the addition of `join` -- so we have a stronger guarantee that the thread is finished.