### PR TITLE
Fix ScientificInput/FloatParameter precision and default value

### DIFF
--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -237,14 +237,18 @@ class ScientificInput(QtGui.QDoubleSpinBox, Input):
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
-        self.setMinimum(parameter.minimum)
-        self.setMaximum(parameter.maximum)
+        self._parameter = parameter  # required before super().set_parameter
+        # for self.validate which is called when setting self.decimals()
         self.validator = QtGui.QDoubleValidator(
             parameter.minimum,
             parameter.maximum,
-            10, self)
+            parameter.decimals,
+            self)
+        self.setDecimals(parameter.decimals)
+        self.setMinimum(parameter.minimum)
+        self.setMaximum(parameter.maximum)
         self.validator.setNotation(QtGui.QDoubleValidator.ScientificNotation)
-        super().set_parameter(parameter) # default gets set here, after min/max
+        super().set_parameter(parameter)  # default gets set here, after min/max
 
     def validate(self, text, pos):
         if self._parameter.units:

--- a/pymeasure/experiment/parameters.py
+++ b/pymeasure/experiment/parameters.py
@@ -155,15 +155,18 @@ class FloatParameter(Parameter):
     :param units: The units of measure for the parameter
     :param minimum: The minimum allowed value (default: -1e9)
     :param maximum: The maximum allowed value (default: 1e9)
+    :param decimals: The number of decimals considered (default: 15)
     :param default: The default floating point value
     :param ui_class: A Qt class to use for the UI of this parameter
     """
 
-    def __init__(self, name, units=None, minimum=-1e9, maximum=1e9, **kwargs):
+    def __init__(self, name, units=None, minimum=-1e9, maximum=1e9,
+                 decimals=15, **kwargs):
         super().__init__(name, **kwargs)
         self.units = units
         self.minimum = minimum
         self.maximum = maximum
+        self.decimals = decimals
 
     @property
     def value(self):

--- a/tests/display/test_inputs.py
+++ b/tests/display/test_inputs.py
@@ -136,7 +136,9 @@ class TestScientificInput:
     @pytest.mark.parametrize("min_,max_,default_value", [
         [0, 20, 12],
         [0, 1000, 200], # regression #118: default above default max 99.99
-        [-1000, 1000, -10] # regression #118: default below default min 0
+        [-1000, 1000, -10], # regression #118: default below default min 0
+        [0.004, 5.5, 3.3],  # minimum #225: 0 < minimum < 0.005
+        [0, 0.01, 0.002]  # default #233: default <0.01 changes to 0
     ])
     def test_init_from_param(self, qtbot, min_, max_, default_value):
         float_param = FloatParameter('potato',


### PR DESCRIPTION
Hi,
this should fix the issues described in #233 and #225 which are related to the default precisison of 2 of `QDoubleSpinBox`. I introduced the new keyword argument `decimals` for the `FloatParameter` to adjust the precision of the input box (and the value passed to the instrument!) manually. I set the default to 15, as I think femto-something should be sufficient for most parameters.

I also changed to set the `self._parameter` attribute in the derived `set_parameter` method already, since this is required by the validator. The validator may already get called when setting minimum, maximum and decimals and requires `self._parameter.units`. (also seen in #225)

As always, happy for remarks and improvements on the code.