### PR TITLE
Correct pyVISA kwarg query_delay.

### DIFF
--- a/pymeasure/adapters/visa.py
+++ b/pymeasure/adapters/visa.py
@@ -56,7 +56,7 @@ class VISAAdapter(Adapter):
         self.resource_name = resourceName
         self.manager = visa.ResourceManager(visa_library)
         safeKeywords = ['resource_name', 'timeout',
-                        'chunk_size', 'lock', 'delay', 'send_end',
+                        'chunk_size', 'lock', 'query_delay', 'send_end',
                         'values_format', 'read_termination', 'write_termination']
         kwargsCopy = copy.deepcopy(kwargs)
         for key in kwargsCopy:

--- a/pymeasure/instruments/agilent/agilent34410A.py
+++ b/pymeasure/instruments/agilent/agilent34410A.py
@@ -43,7 +43,7 @@ class Agilent34410A(Instrument):
     
     resistance_4w = Instrument.measurement("MEAS:FRES? DEF,DEF", "Four-wires (remote sensing) resistance, in Ohms")
     
-    def __init__(self, adapter, delay=0.02, **kwargs):
+    def __init__(self, adapter, **kwargs):
         super(Agilent34410A, self).__init__(
             adapter, "HP/Agilent/Keysight 34410A Multimeter", **kwargs
         )

--- a/pymeasure/instruments/agilent/agilent8257D.py
+++ b/pymeasure/instruments/agilent/agilent8257D.py
@@ -245,7 +245,7 @@ class Agilent8257D(Instrument):
         map_values=True
     )
 
-    def __init__(self, adapter, delay=0.02, **kwargs):
+    def __init__(self, adapter, **kwargs):
         super(Agilent8257D, self).__init__(
             adapter, "Agilent 8257D RF Signal Generator", **kwargs
         )

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -21,16 +21,22 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+import importlib.util
+
+import pytest
 from pytest import approx
 
 from pymeasure.adapters import VISAAdapter
 from pymeasure.instruments import Instrument
+
+pyvisa_sim_installed = bool(importlib.util.find_spec('pyvisa-sim'))
 
 
 def test_visa_version():
     assert VISAAdapter.has_supported_version()
 
 
+@pytest.mark.skipif(not pyvisa_sim_installed, reason='pyvisa-sim required but not found.')
 def test_correct_visa_kwarg():
     """Confirm that the query_delay kwargs gets passed through to the VISA connection."""
     instr = Instrument(adapter='ASRL1::INSTR', name='delayed', query_delay=0.5, visa_library='@sim')

--- a/tests/adapters/test_visa.py
+++ b/tests/adapters/test_visa.py
@@ -21,8 +21,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
+from pytest import approx
 
 from pymeasure.adapters import VISAAdapter
+from pymeasure.instruments import Instrument
+
 
 def test_visa_version():
-  assert VISAAdapter.has_supported_version()
+    assert VISAAdapter.has_supported_version()
+
+
+def test_correct_visa_kwarg():
+    """Confirm that the query_delay kwargs gets passed through to the VISA connection."""
+    instr = Instrument(adapter='ASRL1::INSTR', name='delayed', query_delay=0.5, visa_library='@sim')
+    assert instr.adapter.connection.query_delay == approx(0.5)


### PR DESCRIPTION
 Correct VISAAdapter keyword argument "query_delay" instead of the removed "delay".

This was overlooked in the migration to PyVISA 1.6. Also remove instances where the old "delay" kwarg was defined but unused.

Add the instrument test only if pyvisa-sim is installed. pyvisa-sim is not available via conda-forge, so don't place it in the list of dependencies just for this one test.

Closes #272

