### PR TITLE
Fix error in Keithley instrument implementations.

### DIFF
--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -624,7 +624,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
     @property
     def max_resistance(self):
         """ Returns the maximum resistance from the buffer """
-        return self.maximums()[2]
+        return self.maximums[2]
 
     @property
     def min_resistance(self):

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -502,7 +502,7 @@ class Keithley2450(Instrument, KeithleyBuffer):
     @property
     def max_resistance(self):
         """ Returns the maximum resistance from the buffer """
-        return self.maximums()[2]
+        return self.maximums[2]
 
     @property
     def min_resistance(self):


### PR DESCRIPTION
Accessing these properties understandably fails.
Probably those slipped in due to autocomplete, compare the accompanying min_resistance definition.