### PR TITLE
Updated buggy "quick_range"

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -20,3 +20,4 @@ Michael Schneider
 Dennis Feng
 Stefano Pirotta
 Moritz Jung
+Mikhaël Myara

--- a/docs/api/instruments/thorlabs/index.rst
+++ b/docs/api/instruments/thorlabs/index.rst
@@ -10,3 +10,4 @@ This section contains specific documentation on the Thorlabs instruments that ar
    :maxdepth: 2
 
    thorlabspm100usb
+   thorlabspro8000

--- a/docs/api/instruments/thorlabs/thorlabspro8000.rst
+++ b/docs/api/instruments/thorlabs/thorlabspro8000.rst
@@ -1,0 +1,3 @@
+.. autoclass:: pymeasure.instruments.thorlabs.ThorlabsPro8000
+    :members:
+    :show-inheritance:

--- a/pymeasure/instruments/srs/sr830.py
+++ b/pymeasure/instruments/srs/sr830.py
@@ -353,12 +353,16 @@ class SR830(Instrument):
         """ While the magnitude is out of range, increase
         the sensitivity by one setting
         """
+        self.write('LIAE 2,1')
         while self.is_out_of_range():
             self.write("SENS%d" % (int(self.ask("SENS?"))+1))
             time.sleep(5.0*self.time_constant)
             self.write("*CLS")
         # Set the range as low as possible
-        self.sensitivity(1.15*abs(self.R))
+        newsensitivity = 1.15*abs(self.magnitude)
+        if self.input_config in('I (1 MOhm)','I (100 MOhm)'):
+            newsensitivity = newsensitivity*1e6
+        self.sensitivity = newsensitivity
 
     @property
     def buffer_count(self):

--- a/pymeasure/instruments/thorlabs/__init__.py
+++ b/pymeasure/instruments/thorlabs/__init__.py
@@ -23,4 +23,4 @@
 #
 
 from .thorlabspm100usb import ThorlabsPM100USB
-from .thorlabspro8000 import thorlabsPro8000
+from .thorlabspro8000 import ThorlabsPro8000

--- a/pymeasure/instruments/thorlabs/__init__.py
+++ b/pymeasure/instruments/thorlabs/__init__.py
@@ -23,3 +23,4 @@
 #
 
 from .thorlabspm100usb import ThorlabsPM100USB
+from .thorlabspro8000 import thorlabsPro8000

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -11,7 +11,7 @@
 # furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# all copies or @@substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -31,7 +31,7 @@ import time
 import re
 
 
-class thorlabsPro8000(Instrument):
+class ThorlabsPro8000(Instrument):
     """Represents Thorlabs Pro 8000 modular laser driver"""
     SLOTS = range(1,9)
     LDC_POLARITIES = ['AG', 'CG']
@@ -39,7 +39,7 @@ class thorlabsPro8000(Instrument):
 
 
     def __init__(self, resourceName, **kwargs):
-        super(thorlabsPro8000, self).__init__(
+        super(ThorlabsPro8000, self).__init__(
             resourceName,
             "Thorlabs Pro 8000",
             **kwargs

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -11,7 +11,7 @@
 # furnished to do so, subject to the following conditions:
 #
 # The above copyright notice and this permission notice shall be included in
-# all copies or @@substantial portions of the Software.
+# all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -1,0 +1,79 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from pymeasure.instruments import Instrument, discreteTruncate
+from pymeasure.instruments.validators import strict_discrete_set, \
+    truncated_discrete_set, truncated_range
+
+import numpy as np
+import time
+import re
+
+
+class thorlabsPro8000(Instrument):
+    """Represents Thorlabs Pro 8000 modular laser driver"""
+    SLOTS = range(1,9)
+    LDC_POLARITIES = ['AG', 'CG']
+    STATUS = ['ON','OFF']
+
+
+    def __init__(self, resourceName, **kwargs):
+        super(thorlabsPro8000, self).__init__(
+            resourceName,
+            "Thorlabs Pro 8000",
+            **kwargs
+        )
+        self.write(':SYST:ANSW VALUE')
+
+    # Code for general purpose commands (mother board related)
+    slot = Instrument.control(":SLOT?", ":SLOT %d",
+                                "Slot selection. Allowed values are: {}""".format(SLOTS),
+                                validator=strict_discrete_set,
+                                values=SLOTS,
+                                map_values=False)
+
+    # Code for LDC-xxxx daughter boards (laser driver)
+    LDCCurrent = Instrument.control(":ILD:SET?", ":ILD:SET %g",
+                                """Laser current.""")
+    LDCCurrentLimit = Instrument.control(":LIMC:SET?", ":LIMC:SET %g",
+                                """Set Software current Limit (value must be lower than hardware current limit).""")
+    LDCPolarity = Instrument.control(":LIMC:SET?", ":LIMC:SET %s",
+                                """Set laser diode polarity. Allowed values are: {}""".format(LDC_POLARITIES),
+                                validator=strict_discrete_set,
+                                values=LDC_POLARITIES,
+                                map_values=False)
+    LDCStatus = Instrument.control(":LASER?", ":LASER %s",
+                                """Set laser diode status. Allowed values are: {}""".format(STATUS),
+                                validator=strict_discrete_set,
+                                values=STATUS,
+                                map_values=False)
+
+    # Code for TED-xxxx daughter boards (laser driver)
+    TEDStatus = Instrument.control(":TEC?", ":TEC %s",
+                                """Set TEC status. Allowed values are: {}""".format(STATUS),
+                                validator=strict_discrete_set,
+                                values=STATUS,
+                                map_values=False)
+    TEDSetTemperature = Instrument.control(":TEMP:SET?", ":TEMP:SET %g",
+                                """Set TEC temperature""")

--- a/pymeasure/instruments/thorlabs/thorlabspro8000.py
+++ b/pymeasure/instruments/thorlabs/thorlabspro8000.py
@@ -69,7 +69,7 @@ class ThorlabsPro8000(Instrument):
                                 values=STATUS,
                                 map_values=False)
 
-    # Code for TED-xxxx daughter boards (laser driver)
+    # Code for TED-xxxx daughter boards (TEC driver)
     TEDStatus = Instrument.control(":TEC?", ":TEC %s",
                                 """Set TEC status. Allowed values are: {}""".format(STATUS),
                                 validator=strict_discrete_set,


### PR DESCRIPTION
- did not work with transimpedance modes (1 MOhm and 100 Mohm)
- there were an access to not-existing "self.R" field, replaced by "self.sensitivity"
- enabled the 'LIAE 2,1' request bit to allow overflow detection.