### PR TITLE
Dev/rigol dg4000

### DIFF
--- a/pymeasure/instruments/rigol/__init__.py
+++ b/pymeasure/instruments/rigol/__init__.py
@@ -22,32 +22,4 @@
 # THE SOFTWARE.
 #
 
-from ..errors import RangeError, RangeException
-from .instrument import Instrument
-from .mock import Mock
-from .resources import list_resources
-from .validators import discreteTruncate
-
-from . import advantest
-from . import agilent
-from . import ametek
-from . import ami
-from . import anapico
-from . import anritsu
-from . import danfysik
-from . import deltaelektronika
-from . import fwbell
-from . import hp
-from . import keithley
-from . import keysight
-from . import lakeshore
-from . import newport
-from . import ni
-from . import oxfordinstruments
-from . import parker
-from . import signalrecovery
-from . import srs
-from . import rigol
-from . import tektronix
-from . import thorlabs
-from . import yokogawa
+from .rigolDG4000 import RigolDG4000

--- a/pymeasure/instruments/rigol/rigolDG4000.py
+++ b/pymeasure/instruments/rigol/rigolDG4000.py
@@ -1,0 +1,48 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import (
+    truncated_range, truncated_discrete_set,
+    strict_discrete_set
+)
+from pymeasure.adapters import VISAAdapter
+from .buffer import KeithleyBuffer
+
+
+
+class RigolDG4000(Instrument):
+    """Represents any Rigol DG4000 series function generator
+    """
+
+    def __init__(self, resourceName,**kwargs):
+        super(RigolDG4000, self).__init__(
+            resourceName,
+            "Rigol DG4000",
+            **kwargs
+        )


### PR DESCRIPTION
WIP

Starting PR after following instructions on the contribution page.
This is day 1 of learning Python so early review and guidance is welcome.
Currently working on supporting the Rigol DG4000 family of function generators.
This mainly consists of transferring GPIB commands listed in the Feb 2014 version of the instruments programming guide document. 
Code will be tested on a DG4062 instrument using LXI/VISA connection.