### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -315,7 +315,7 @@ class ImageFrame(QtGui.QFrame):
     def parse_axis(self, axis):
         """ Returns the units of an axis by searching the string
         """
-        units_pattern = "\((?P<units>\w+)\)"
+        units_pattern = r"\((?P<units>\w+)\)"
         try:
             match = re.search(units_pattern, axis)
         except TypeError:


### PR DESCRIPTION
Fixes #292 . Similar to #192 .

They are compile time warnings and can be found with the command `find . -iname '*.py' | xargs -P4 -I{} python3.10 -Wall -m py_compile {}`