### PR TITLE
keithley2700: dont crash on unknown card

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,3 +21,4 @@ Dennis Feng
 Stefano Pirotta
 Moritz Jung
 Mikhaël Myara
+John McMaster

--- a/pymeasure/instruments/keithley/keithley2700.py
+++ b/pymeasure/instruments/keithley/keithley2700.py
@@ -171,6 +171,7 @@ class Keithley2700(Instrument, KeithleyBuffer):
                 log.warning(
                     "Card type %s at slot %s is not yet implemented." % (card, slot)
                 )
+                continue
 
             channels = [100 * slot + ch for ch in channels]
 


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "test3.py", line 20, in <module>
    kmeter = Keithley2700(adapter.gpib(5))
  File "/home/mcmaster/doc/ext/pymeasure/pymeasure/instruments/keithley/keithley2700.py", line 150, in __init__
    self.determine_valid_channels()
  File "/home/mcmaster/doc/ext/pymeasure/pymeasure/instruments/keithley/keithley2700.py", line 175, in determine_valid_channels
    channels = [100 * slot + ch for ch in channels]
UnboundLocalError: local variable 'channels' referenced before assignment
```