### PR TITLE
implement the Attocube ANC300 Piezo controller

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,3 +21,4 @@ Dennis Feng
 Stefano Pirotta
 Moritz Jung
 Mikhaël Myara
+Dominik Kriegner

--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -24,3 +24,4 @@ The following developers have contributed to the PyMeasure package:
 | Stefano Pirotta
 | Moritz Jung
 | Manuel Zahn
+| Dominik Kriegner

--- a/docs/api/adapters.rst
+++ b/docs/api/adapters.rst
@@ -63,3 +63,13 @@ VXI-11 adapter
     :undoc-members:
     :inherited-members:
     :show-inheritance: 
+
+==============
+Telnet adapter
+==============
+
+.. autoclass:: pymeasure.adapters.TelnetAdapter
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/api/instruments/attocube/adapters.rst
+++ b/docs/api/instruments/attocube/adapters.rst
@@ -1,0 +1,7 @@
+#################
+Attocube Adapters
+#################
+
+.. autoclass:: pymeasure.instruments.attocube.adapters.AttocubeConsoleAdapter
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/attocube/anc300.rst
+++ b/docs/api/instruments/attocube/anc300.rst
@@ -1,0 +1,11 @@
+#################################
+Attocube ANC300 Motion Controller
+#################################
+
+.. autoclass:: pymeasure.instruments.attocube.anc300.ANC300Controller
+    :members:
+    :show-inheritance:
+
+.. autoclass:: pymeasure.instruments.attocube.anc300.Axis
+    :members:
+    :show-inheritance:

--- a/docs/api/instruments/attocube/index.rst
+++ b/docs/api/instruments/attocube/index.rst
@@ -1,0 +1,13 @@
+.. module:: pymeasure.instruments.attocube
+
+########
+Attocube
+########
+
+This section contains specific documentation on the Attocube instruments that are implemented. If you are interested in an instrument not included, please consider :doc:`adding the instrument </dev/adding_instruments>`.
+
+.. toctree::
+   :maxdepth: 2
+
+   adapters
+   anc300

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -39,7 +39,7 @@ class TelnetAdapter(Adapter):
     :param kwargs: Any valid key-word argument for telnetlib.Telnet
     """
 
-    def __init__(self, host, port, query_delay=0, **kwargs):
+    def __init__(self, host, port=0, query_delay=0, **kwargs):
         self.query_delay = query_delay
         self.connection = telnetlib.Telnet(host, port, **kwargs)
 

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -46,8 +46,8 @@ class TelnetAdapter(Adapter):
         for kw in kwargs:
             if kw not in safe_keywords:
                 raise TypeError(
-                    "TelnetAdapter: unexpected keyword argument '%s', "
-                    "allowed are: %s" % (kw, str(safe_keywords)))
+                    f"TelnetAdapter: unexpected keyword argument '{kw}', "
+                    f"allowed are: {str(safe_keywords)}")
         self.connection = telnetlib.Telnet(host, port, **kwargs)
 
     def __del__(self):

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -1,0 +1,80 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import telnetlib
+import time
+
+from .adapter import Adapter
+
+
+class TelnetAdapter(Adapter):
+    """ Adapter class for using the Python telnetlib package to allow
+    communication to instruments
+
+    :param host: host address of the instrument
+    :param port: TCPIP port
+    :param query_delay: delay in seconds between write and read in the ask
+                        method
+    :param kwargs: Any valid key-word argument for telnetlib.Telnet
+    """
+
+    def __init__(self, host, port, query_delay=0, **kwargs):
+        self.query_delay = query_delay
+        self.connection = telnetlib.Telnet(host, port, **kwargs)
+
+    def __del__(self):
+        """ Ensures the connection is closed upon deletion
+        """
+        self.connection.close()
+
+    def write(self, command):
+        """ Writes a command to the instrument
+
+        :param command: command string to be sent to the instrument
+        """
+        self.connection.write(command.encode())
+
+    def read(self):
+        """ Read something even with blocking the I/O. After something is
+        received check again to obtain a full reply.
+
+        :returns: String ASCII response of the instrument.
+        """
+        return self.connection.read_some().decode() + \
+                self.connection.read_very_eager().decode()
+
+    def ask(self, command):
+        """ Writes a command to the instrument and returns the resulting ASCII
+        response
+
+        :param command: command string to be sent to the instrument
+        :returns: String ASCII response of the instrument
+        """
+        self.write(command)
+        time.sleep(self.query_delay)
+        return self.read()
+
+    def __repr__(self):
+        return "<TelnetAdapter(host=%s, port=%d)>" % (self.connection.host, self.connection.port)
+

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -46,8 +46,8 @@ class TelnetAdapter(Adapter):
         for kw in kwargs:
             if kw not in safe_keywords:
                 raise TypeError(
-                    f"TelnetAdapter: unexpected keyword argument '{kw}', "
-                    f"allowed are: {str(safe_keywords)}")
+                    "TelnetAdapter: unexpected keyword argument '%s', "
+                    "allowed are: %s" % (kw, str(safe_keywords)))
         self.connection = telnetlib.Telnet(host, port, **kwargs)
 
     def __del__(self):

--- a/pymeasure/adapters/telnet.py
+++ b/pymeasure/adapters/telnet.py
@@ -36,11 +36,18 @@ class TelnetAdapter(Adapter):
     :param port: TCPIP port
     :param query_delay: delay in seconds between write and read in the ask
                         method
-    :param kwargs: Any valid key-word argument for telnetlib.Telnet
+    :param kwargs: Valid keyword arguments for telnetlib.Telnet, currently
+    this is only 'timeout'
     """
 
     def __init__(self, host, port=0, query_delay=0, **kwargs):
         self.query_delay = query_delay
+        safe_keywords = ['timeout']
+        for kw in kwargs:
+            if kw not in safe_keywords:
+                raise TypeError(
+                    f"TelnetAdapter: unexpected keyword argument '{kw}', "
+                    f"allowed are: {str(safe_keywords)}")
         self.connection = telnetlib.Telnet(host, port, **kwargs)
 
     def __del__(self):

--- a/pymeasure/instruments/__init__.py
+++ b/pymeasure/instruments/__init__.py
@@ -34,6 +34,7 @@ from . import ametek
 from . import ami
 from . import anapico
 from . import anritsu
+from . import attocube
 from . import danfysik
 from . import deltaelektronika
 from . import fwbell

--- a/pymeasure/instruments/attocube/__init__.py
+++ b/pymeasure/instruments/attocube/__init__.py
@@ -21,27 +21,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import logging
 
-from .adapter import Adapter, FakeAdapter
-
-log = logging.getLogger(__name__)
-log.addHandler(logging.NullHandler())
-
-try:
-    from pymeasure.adapters.visa import VISAAdapter
-except ImportError:
-    log.warning("PyVISA library could not be loaded")
-
-try:
-    from pymeasure.adapters.serial import SerialAdapter
-    from pymeasure.adapters.prologix import PrologixAdapter
-except ImportError:
-    log.warning("PySerial library could not be loaded")
-
-try:
-    from pymeasure.adapters.vxi11 import VXI11Adapter
-except ImportError:
-    log.warning("VXI-11 library could not be loaded")
-
-from pymeasure.adapters.telnet import TelnetAdapter
+from .adapters import AttocubeConsoleAdapter
+from .anc300 import ANC300Controller

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -76,9 +76,11 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         :returns: String ASCII response of the instrument.
         """
         raw = super().read().strip(self.read_termination)
-        lines = raw.split('\n')  # line endings inconsistent '\n', or '\r\n'
-        ret = '\n'.join(line.strip() for line in lines[:-1])
-        self.check_acknowledgement(lines[-1], ret)
+        # one would want to use self.read_termination as 'sep' below, but this
+        # is not possible because of a firmware bug resulting in inconsistent
+        # line endings
+        ret, ack = raw.rsplit(sep='\n', maxsplit=1)
+        self.check_acknowledgement(ack, ret)
         return ret
 
     def write(self, command, checkAck=True):

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -1,0 +1,104 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import time
+
+from pymeasure.adapters import TelnetAdapter
+
+
+class AttocubeConsoleAdapter(TelnetAdapter):
+    """ Adapter class for connecting to the Attocube Standard Console. This
+    console is a Telnet prompt with password authentication.
+
+    :param host: host address of the instrument
+    :param port: TCPIP port
+    :param passwd: password required to open the connection
+    :param kwargs: Any valid key-word argument for TelnetAdapter
+    """
+    def __init__(self, host, port, passwd, **kwargs):
+        self.terminator = '\r\n'
+        super(AttocubeConsoleAdapter, self).__init__(host, port, **kwargs)
+        # clear the initial messages from the controller
+        time.sleep(self.query_delay)
+        super(AttocubeConsoleAdapter, self).read()
+        # send password and check authorization
+        self.write(passwd, checkAck=False)
+        time.sleep(self.query_delay)
+        ret = super(AttocubeConsoleAdapter, self).read()
+        authmsg = ret.split(self.terminator)[1]
+        if authmsg != 'Authorization success':
+            raise Exception("Attocube authorization failed ('%s')" % authmsg)
+        # switch console echo off
+        self.ask('echo off')
+
+    def check_acknowledgement(self, reply, msg=""):
+        """ Reads the reply of the instrument until the termination sequence.
+        The returned string is check to be 'OK' and otherwise a ValueError is
+        raised.
+
+        :param msg: optional message for the eventual error
+        :returns: String ASCII response of the instrument.
+        """
+        if reply.strip() != 'OK':
+            if msg == "":  # clear buffer
+                msg = reply.strip()
+                super(AttocubeConsoleAdapter, self).read()
+            raise ValueError("AttocubeConsoleAdapter: Error after command '%s'"
+                             " with message '%s'" % (self.lastcommand, msg))
+
+    def read(self):
+        """ Reads a reply of the instrument which consists of two or more
+        lines. The first ones are the reply to the command while the last one
+        is 'OK' or 'ERROR' to indicate any problem. In case the reply is not OK
+        a ValueError is raised.
+
+        :returns: String ASCII response of the instrument.
+        """
+        raw = super(AttocubeConsoleAdapter, self).read().strip()
+        lines = raw.split('\n')  # line endings inconsistent '\n', or '\r\n'
+        ret = '\n'.join(line.strip() for line in lines[:-1])
+        self.check_acknowledgement(lines[-1], ret)
+        return ret
+
+    def write(self, command, checkAck=True):
+        """ Writes a command to the instrument
+
+        :param command: command string to be sent to the instrument
+        """
+        self.lastcommand = command
+        super(AttocubeConsoleAdapter, self).write(command + self.terminator)
+        if checkAck:
+            reply = self.connection.read_until(self.terminator.encode())
+            self.check_acknowledgement(reply.decode())
+
+    def ask(self, command):
+        """ Writes a command to the instrument and returns the resulting ASCII
+        response
+
+        :param command: command string to be sent to the instrument
+        :returns: String ASCII response of the instrument
+        """
+        self.write(command, checkAck=False)
+        time.sleep(self.query_delay)
+        return self.read()

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -79,6 +79,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         # is not possible because of a firmware bug resulting in inconsistent
         # line endings
         ret, ack = raw.rsplit(sep='\n', maxsplit=1)
+        ret = ret.strip('\r')  # strip possible CR char
         self.check_acknowledgement(ack, ret)
         return ret
 

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -40,9 +40,8 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         self.read_termination = '\r\n'
         self.write_termination = self.read_termination
         super().__init__(host, port, **kwargs)
-        # clear the initial messages from the controller
         time.sleep(self.query_delay)
-        super().read()
+        super().read()  # clear messages sent upon opening the connection
         # send password and check authorization
         self.write(passwd, checkAck=False)
         time.sleep(self.query_delay)
@@ -51,7 +50,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         if authmsg != 'Authorization success':
             raise Exception("Attocube authorization failed ('%s')" % authmsg)
         # switch console echo off
-        self.ask('echo off')
+        _ = self.ask('echo off')
 
     def check_acknowledgement(self, reply, msg=""):
         """ checks the last reply of the instrument to be 'OK', otherwise a

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -28,7 +28,7 @@ import time
 from pymeasure.adapters import TelnetAdapter
 
 # compiled regular expression for finding numerical values in reply strings
-reg_value = re.compile("\w+\s+=\s+([-+]?[0-9]*\.?[0-9]+)")
+_reg_value = re.compile(r"\w+\s+=\s+([-+]?[0-9]*\.?[0-9]+)")
 
 
 def extract_value(reply):
@@ -38,7 +38,7 @@ def extract_value(reply):
     :param reply: reply string
     :returns: string with only the numerical value
     """
-    r = reg_value.search(reply)
+    r = _reg_value.search(reply)
     if r:
         return r.groups()[0]
     else:

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -39,14 +39,14 @@ class AttocubeConsoleAdapter(TelnetAdapter):
     def __init__(self, host, port, passwd, **kwargs):
         self.read_termination = '\r\n'
         self.write_termination = self.read_termination
-        super(AttocubeConsoleAdapter, self).__init__(host, port, **kwargs)
+        super().__init__(host, port, **kwargs)
         # clear the initial messages from the controller
         time.sleep(self.query_delay)
-        super(AttocubeConsoleAdapter, self).read()
+        super().read()
         # send password and check authorization
         self.write(passwd, checkAck=False)
         time.sleep(self.query_delay)
-        ret = super(AttocubeConsoleAdapter, self).read()
+        ret = super().read()
         authmsg = ret.split(self.read_termination)[1]
         if authmsg != 'Authorization success':
             raise Exception("Attocube authorization failed ('%s')" % authmsg)
@@ -64,7 +64,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         if reply != 'OK':
             if msg == "":  # clear buffer
                 msg = reply
-                super(AttocubeConsoleAdapter, self).read()
+                super().read()
             raise ValueError("AttocubeConsoleAdapter: Error after command '%s'"
                              " with message '%s'" % (self.lastcommand, msg))
 
@@ -76,8 +76,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
 
         :returns: String ASCII response of the instrument.
         """
-        raw = super(AttocubeConsoleAdapter,
-                self).read().strip(self.read_termination)
+        raw = super().read().strip(self.read_termination)
         lines = raw.split('\n')  # line endings inconsistent '\n', or '\r\n'
         ret = '\n'.join(line.strip() for line in lines[:-1])
         self.check_acknowledgement(lines[-1], ret)
@@ -89,7 +88,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         :param command: command string to be sent to the instrument
         """
         self.lastcommand = command
-        super(AttocubeConsoleAdapter, self).write(command +
+        super().write(command +
                                                   self.write_termination)
         if checkAck:
             reply = self.connection.read_until(self.read_termination.encode())

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -28,7 +28,7 @@ import time
 from pymeasure.adapters import TelnetAdapter
 
 # compiled regular expression for finding numerical values in reply strings
-_reg_value = re.compile(r"\w+\s+=\s+([-+]?[0-9]*\.?[0-9]+)")
+_reg_value = re.compile(r"\w+\s+=\s+(\w+)")
 
 
 def extract_value(reply):

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -54,12 +54,11 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         self.ask('echo off')
 
     def check_acknowledgement(self, reply, msg=""):
-        """ Reads the reply of the instrument until the termination sequence.
-        The returned string is check to be 'OK' and otherwise a ValueError is
-        raised.
+        """ checks the last reply of the instrument to be 'OK', otherwise a
+        ValueError is raised.
 
+        :param reply: last reply string of the instrument
         :param msg: optional message for the eventual error
-        :returns: String ASCII response of the instrument.
         """
         if reply != 'OK':
             if msg == "":  # clear buffer
@@ -86,10 +85,12 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         """ Writes a command to the instrument
 
         :param command: command string to be sent to the instrument
+        :param checkAck: boolean flag to decide if the acknowledgement is read
+        back from the instrument. This should be True for set pure commands and
+        False otherwise.
         """
         self.lastcommand = command
-        super().write(command +
-                                                  self.write_termination)
+        super().write(command + self.write_termination)
         if checkAck:
             reply = self.connection.read_until(self.read_termination.encode())
             msg = reply.decode().strip(self.read_termination)

--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -86,7 +86,7 @@ class AttocubeConsoleAdapter(TelnetAdapter):
         ret = super().read()
         authmsg = ret.split(self.read_termination)[1]
         if authmsg != 'Authorization success':
-            raise Exception("Attocube authorization failed ('%s')" % authmsg)
+            raise Exception(f"Attocube authorization failed '{authmsg}'")
         # switch console echo off
         _ = self.ask('echo off')
 
@@ -101,8 +101,8 @@ class AttocubeConsoleAdapter(TelnetAdapter):
             if msg == "":  # clear buffer
                 msg = reply
                 super().read()
-            raise ValueError("AttocubeConsoleAdapter: Error after command '%s'"
-                             " with message '%s'" % (self.lastcommand, msg))
+            raise ValueError("AttocubeConsoleAdapter: Error after command "
+                             f"{self.lastcommand} with message {msg}")
 
     def read(self):
         """ Reads a reply of the instrument which consists of two or more

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -98,14 +98,15 @@ class Axis(object):
             validator=strict_range, values=[0, 150],
             get_process=extract_float)
 
-    output_voltage = Instrument.measurement("geto",
-                                            """ Output voltage in volts.""",
-                                            get_process=extract_float)
+    output_voltage = Instrument.measurement(
+            "geto",
+            """ Output voltage in volts.""",
+            get_process=extract_float)
 
-    capacity = Instrument.measurement("getc",
-                                      """ Saved capacity value in nF of the
-                                      axis.""",
-                                      get_process=extract_float)
+    capacity = Instrument.measurement(
+            "getc",
+            """ Saved capacity value in nF of the axis.""",
+            get_process=extract_float)
 
     stepu = Instrument.setting(
             "stepu %d",
@@ -119,7 +120,7 @@ class Axis(object):
             positive.""",
             validator=strict_range, values=[0, inf])
 
-    def __init__(self, axis, controller):
+    def __init__(self, controller, axis):
         self.axis = str(axis)
         self.controller = controller
 
@@ -210,7 +211,7 @@ class ANC300Controller(Instrument):
             **kwargs
         )
         for i, axis in enumerate(axisnames):
-            setattr(self, axis, Axis(i+1, self))
+            setattr(self, axis, Axis(self, i+1))
 
     def ground_all(self):
         """ Grounds all axis of the controller. """

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -191,6 +191,7 @@ class ANC300Controller(Instrument):
     :param axisnames: a list of axis names which will be used to create
                       properties with these names
     :param passwd: password for the attocube standard console
+    :param query_delay: delay between sending and reading (default 0.05 sec)
     :param kwargs: Any valid key-word argument for TelnetAdapter
     """
     version = Instrument.measurement(
@@ -201,9 +202,8 @@ class ANC300Controller(Instrument):
            "getcser", """ Serial number of the controller board """
            )
 
-    def __init__(self, host, axisnames, passwd, **kwargs):
-        if 'query_delay' not in kwargs:
-            kwargs['query_delay'] = 0.05
+    def __init__(self, host, axisnames, passwd, query_delay=0.05, **kwargs):
+        kwargs['query_delay'] = query_delay
         super().__init__(
             AttocubeConsoleAdapter(host, 7230, passwd, **kwargs),
             "attocube ANC300 Piezo Controller",

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -25,38 +25,11 @@
 from math import inf
 
 from pymeasure.instruments import Instrument
+from pymeasure.instruments.attocube.adapters import (AttocubeConsoleAdapter,
+                                                     extract_float,
+                                                     extract_int,
+                                                     extract_value)
 from pymeasure.instruments.validators import strict_discrete_set, strict_range
-from pymeasure.instruments.attocube.adapters import AttocubeConsoleAdapter
-
-
-def extract_value(reply):
-    """ get_process function for the Attocube console which for numerical
-    values typically return 'name = X.YZ unit'
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    return reply.split('=')[1].split()[0]
-
-
-def extract_float(reply):
-    """ get_process function for the Attocube console to obtain a float from
-    the reply
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    return float(extract_value(reply))
-
-
-def extract_int(reply):
-    """ get_process function for the Attocube console to obtain an integer from
-    the reply
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    return int(extract_value(reply))
 
 
 class Axis(object):

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -42,25 +42,18 @@ def strict_length(value, values):
 
 
 def truncated_int_array(value, values):
-    """ validator function to check if the supplied value is an iterable-object
-    with appropriate values.
-    """
     ret = []
     for i, v in enumerate(value):
-        if v < values[0]:
-            ret.append(values[0])
-        elif v > values[1]:
-            ret.append(values[1])
-        elif isinstance(v, float):
-            if v.is_integer():
-                ret.append(int(v))
+        if values[0] <= v <= values[1]:
+            if float(v).is_integer():
+               ret.append(int(v))
             else:
-                raise ValueError(
-                        f"Entry {v} at index {i} has no integer value")
-        elif isinstance(v, int):
-            ret.append(v)
+               raise ValueError(f"Entry {v} at index {i} has no integer value")
+        elif float(v).is_integer():
+            ret.append(max(min(values[1], v), values[0]))
         else:
-            raise TypeError(f"Entry {v} at index {i} has the wrong data type")
+            raise ValueError(f"Entry {v} at index {i} has no integer value and"
+                             f"is out of the boundaries {values}")
     return ret
 
 

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -1,0 +1,227 @@
+#
+# This file is part of the PyMeasure package.
+#
+# Copyright (c) 2013-2020 PyMeasure Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from math import inf
+
+from pymeasure.instruments import Instrument
+from pymeasure.instruments.validators import strict_discrete_set, strict_range
+from pymeasure.instruments.attocube.adapters import AttocubeConsoleAdapter
+
+
+def extract_value(reply):
+    """ get_process function for the Attocube console which for numerical
+    values typically return 'name = X.YZ unit'
+
+    :param reply: reply string
+    :returns: string with only the numerical value
+    """
+    return reply.split('=')[1].split()[0]
+
+
+def extract_float(reply):
+    """ get_process function for the Attocube console to obtain a float from
+    the reply
+
+    :param reply: reply string
+    :returns: string with only the numerical value
+    """
+    return float(extract_value(reply))
+
+
+def extract_int(reply):
+    """ get_process function for the Attocube console to obtain an integer from
+    the reply
+
+    :param reply: reply string
+    :returns: string with only the numerical value
+    """
+    return int(extract_value(reply))
+
+
+class Axis(object):
+    """ Represents a single open loop axis of the Attocube ANC350
+
+    :param axis: axis identifier, integer from 1 to 7
+    :param controller: ANC300Controller instance used for the communication
+    """
+
+    serial_nr = Instrument.measurement("getser",
+                                       "Serial number of the axis")
+
+    voltage = Instrument.control(
+            "getv", "setv %.3f",
+            """ Amplitude of the stepping voltage in volts from 0 to 150 V. This
+            property can be set. """,
+            validator=strict_range, values=[0, 150],
+            get_process=extract_float)
+
+    frequency = Instrument.control(
+            "getf", "setf %.3f",
+            """ Frequency of the stepping motion in Hertz from 0 to 10000 Hz.
+            This property can be set. """,
+            validator=strict_range, values=[0, 10000],
+            get_process=extract_int)
+
+    mode = Instrument.control(
+            "getm", "setm %s",
+            """ Axis mode. This can be 'gnd', 'inp', 'cap', 'stp', 'off',
+            'stp+', 'stp-'. Available modes depend on the actual axis model""",
+            validator=strict_discrete_set,
+            values=['gnd', 'inp', 'cap', 'stp', 'off', 'stp+', 'stp-'],
+            get_process=extract_value)
+
+    offset_voltage = Instrument.control(
+            "geta", "seta %.3f",
+            """ Offset voltage in Volts from 0 to 150 V.
+            This property can be set. """,
+            validator=strict_range, values=[0, 150],
+            get_process=extract_float)
+
+    output_voltage = Instrument.measurement("geto",
+                                            """ Output voltage in volts.""",
+                                            get_process=extract_float)
+
+    capacity = Instrument.measurement("getc",
+                                      """ Saved capacity value in nF of the
+                                      axis.""",
+                                      get_process=extract_float)
+
+    stepu = Instrument.setting(
+            "stepu %d",
+            """ Step upwards for N steps. Mode must be 'stp' and N must be
+            positive.""",
+            validator=strict_range, values=[0, inf])
+
+    stepd = Instrument.setting(
+            "stepd %d",
+            """ Step downwards for N steps. Mode must be 'stp' and N must be
+            positive.""",
+            validator=strict_range, values=[0, inf])
+
+    def __init__(self, axis, controller):
+        self.axis = str(axis)
+        self.controller = controller
+
+    def _add_axis_id(self, command):
+        """ add axis id to a command string at the correct position after the
+        initial command, but before a potential value
+
+        :param command: command string
+        :returns: command string with added axis id
+        """
+        cmdparts = command.split()
+        cmdparts.insert(1, self.axis)
+        return ' '.join(cmdparts)
+
+    def ask(self, command, **kwargs):
+        return self.controller.ask(self._add_axis_id(command), **kwargs)
+
+    def write(self, command, **kwargs):
+        return self.controller.write(self._add_axis_id(command), **kwargs)
+
+    def values(self, command, **kwargs):
+        return self.controller.values(self._add_axis_id(command), **kwargs)
+
+    def stop(self):
+        """ Stop any motion of the axis """
+        self.write('stop')
+
+    def move(self, steps, gnd=True):
+        """ Move 'steps' steps in the direction given by the sign of the
+        argument. This method will change the mode of the axis automatically
+        and ground the axis on the end if 'gnd' is True. The method returns
+        only when the movement is finished.
+
+        :param steps: finite integer value of steps to be performed. A positive
+        sign corresponds to upwards steps, a negative sign to downwards steps.
+        :param gnd: bool, flag to decide if the axis should be grounded after
+        completion of the movement
+        """
+        self.mode = 'stp'
+        # perform the movement
+        if steps > 0:
+            self.stepu = steps
+        elif steps < 0:
+            self.stepd = abs(steps)
+        else:
+            pass  # do not set stepu/d to 0 since it triggers a continous move
+        # wait for the move to finish
+        self.write('stepw')
+        if gnd:
+            self.mode = 'gnd'
+
+    def measure_capacity(self):
+        """ Obtains a new measurement of the capacity. The mode of the axis
+        returns to 'gnd' after the measurement.
+
+        :returns capacity: the freshly measured capacity in nF.
+        """
+        self.mode = 'cap'
+        # wait for the measurement to finish
+        self.ask('capw')
+        return self.capacity
+
+
+class ANC300Controller(Instrument):
+    """ Attocube ANC300 Piezo stage controller with several axes
+
+    :param host: host address of the instrument
+    :param axisnames: a list of axis names which will be used to create
+                      properties with these names
+    :param passwd: password for the attocube standard console
+    :param kwargs: Any valid key-word argument for TelnetAdapter
+    """
+    version = Instrument.measurement(
+           "ver", """ Version number and instrument identification """
+           )
+
+    controllerBoardVersion = Instrument.measurement(
+           "getcser", """ Serial number of the controller board """
+           )
+
+    def __init__(self, host, axisnames, passwd, **kwargs):
+        if 'query_delay' not in kwargs:
+            kwargs['query_delay'] = 0.05
+        super(ANC300Controller, self).__init__(
+            AttocubeConsoleAdapter(host, 7230, passwd, **kwargs),
+            "attocube ANC300 Piezo Controller",
+            includeSCPI = False,
+            **kwargs
+        )
+        for i, axis in enumerate(axisnames):
+            setattr(self, axis, Axis(i+1, self))
+
+    def ground_all(self):
+        """ Grounds all axis of the controller. """
+        for attr in dir(self):
+            attribute = getattr(self, attr)
+            if isinstance(attribute, Axis):
+                attribute.mode = 'gnd'
+
+    def stop_all(self):
+        """ Stop all movements of the axis. """
+        for attr in dir(self):
+            attribute = getattr(self, attr)
+            if isinstance(attribute, Axis):
+                attribute.stop()

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -78,9 +78,9 @@ class Axis(object):
 
     frequency = Instrument.control(
             "getf", "setf %.3f",
-            """ Frequency of the stepping motion in Hertz from 0 to 10000 Hz.
+            """ Frequency of the stepping motion in Hertz from 1 to 10000 Hz.
             This property can be set. """,
-            validator=strict_range, values=[0, 10000],
+            validator=strict_range, values=[1, 10000],
             get_process=extract_int)
 
     mode = Instrument.control(

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -204,7 +204,7 @@ class ANC300Controller(Instrument):
     def __init__(self, host, axisnames, passwd, **kwargs):
         if 'query_delay' not in kwargs:
             kwargs['query_delay'] = 0.05
-        super(ANC300Controller, self).__init__(
+        super().__init__(
             AttocubeConsoleAdapter(host, 7230, passwd, **kwargs),
             "attocube ANC300 Piezo Controller",
             includeSCPI = False,

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -37,8 +37,7 @@ from pymeasure.instruments.validators import (joined_validators,
 def strict_length(value, values):
     if len(value) != values:
         raise ValueError(
-            'Value {} does not have an appropriate length of {}'.format(
-            value, values))
+            f"Value {value} does not have an appropriate length of {values}")
     return value
 
 
@@ -57,12 +56,11 @@ def truncated_int_array(value, values):
                 ret.append(int(v))
             else:
                 raise ValueError(
-                    'Entry {} at index {} has no integer value'.format(v, i))
+                        f"Entry {v} at index {i} has no integer value")
         elif isinstance(v, int):
             ret.append(v)
         else:
-            raise TypeError(
-                "Entry {} at index {} has the wrong data type".format(v, i))
+            raise TypeError(f"Entry {v} at index {i} has the wrong data type")
     return ret
 
 


### PR DESCRIPTION
this device needs a custom adapter which is derived from the Python standard module telnetlib. Since a general TelnetAdapter could be useful also for other devices I included a general TelnetAdapter from which the specialized Attocube Adapter is derived. 