### PR TITLE
Add widget for controlling and reading instruments

### DIFF
--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -1020,9 +1020,9 @@ class InstrumentWidget(QtGui.QWidget):
         self.instrument = instrument
 
         if hasattr(self.instrument, 'name'):
-            self.name = self.instrument.name
+            self.instrument_name = self.instrument.name
         else:
-            self.name = 'Instrument'
+            self.instrument_name = 'Instrument'
 
         if isinstance(readings, str):
             readings = [readings]

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -1008,11 +1008,37 @@ class SequencerWidget(QtGui.QWidget):
         return evaluated_string
 
 
-class InstrumentControlWidget(QtGui.QWidget):
+class InstrumentWidget(QtGui.QWidget):
     """
     TODO: Write docstrings
 
     """
 
-    def __init__(self, instrument, parent=None):
+    def __init__(self, instrument, readings=None, settings=None, parent=None):
         super().__init__(parent)
+
+        self.instrument = instrument
+
+        if hasattr(self.instrument, 'name'):
+            self.name = self.instrument.name
+        else:
+            self.name = 'Instrument'
+
+        if isinstance(readings, str):
+            readings = [readings]
+
+        self.readings = readings
+
+        if isinstance(settings, str):
+            settings = [settings]
+
+        self.settings = settings
+
+        self._setup_ui()
+        self._layout()
+
+    def _setup_ui(self):
+        pass
+
+    def _layout(self):
+        pass

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -1006,3 +1006,13 @@ class SequencerWidget(QtGui.QWidget):
 
         evaluated_string = numpy.array(evaluated_string)
         return evaluated_string
+
+
+class InstrumentControlWidget(QtGui.QWidget):
+    """
+    TODO: Write docstrings
+
+    """
+
+    def __init__(self, instrument, parent=None):
+        super().__init__(parent)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -518,7 +518,7 @@ class ManagedWindow(QtGui.QMainWindow):
             parent=self
         )
 
-        sequencer_dock = QtGui.QDockWidget(widget.name)
+        sequencer_dock = QtGui.QDockWidget(widget.instrument_name)
         sequencer_dock.setWidget(widget)
         # TODO: consider whether dock-widget-features might be useful (e.g. large panel for better sight)
         sequencer_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -39,6 +39,7 @@ from .widgets import (
     ResultsDialog,
     SequencerWidget,
     ImageWidget,
+    InstrumentWidget,
 )
 from ..experiment.results import Results
 
@@ -504,6 +505,25 @@ class ManagedWindow(QtGui.QMainWindow):
         if not self.manager.experiments.has_next():
             self.abort_button.setEnabled(False)
             self.browser_widget.clear_button.setEnabled(True)
+
+    def add_instrument_widget(self, instrument,
+                              readings=None, settings=None):
+        """ Method that adds an InstrumentWidget to the ManagedWindow.
+        TODO: finish docstring
+        """
+        widget = InstrumentWidget(
+            instrument,
+            readings=readings,
+            settings=settings,
+            parent=self
+        )
+
+        sequencer_dock = QtGui.QDockWidget(widget.name)
+        sequencer_dock.setWidget(widget)
+        # TODO: consider whether dock-widget-features might be useful (e.g. large panel for better sight)
+        sequencer_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
+        self.addDockWidget(QtCore.Qt.TopDockWidgetArea, sequencer_dock)
+
 
 
 # TODO: Inheret from ManagedWindow to share code and features


### PR DESCRIPTION
### Work in progress

An addition that allows for easily adding widgets that can display values of instruments and control its settings from within the software.

- [ ] Finish basic working of widget
- [ ] Add possibility for custom instrument-widgets
- [ ] Move to the standard inputs (i.e. ScientificInput, BooleanInput, etc.) in stead of only spinbox and try to get default, limits etc from the property itself (i.e. not requiring to manually define the limits)
- [ ] Look at best way of displaying the values