### PR TITLE
use preprocess_reply functionality in Attocube ANC300

### DIFF
--- a/pymeasure/instruments/attocube/adapters.py
+++ b/pymeasure/instruments/attocube/adapters.py
@@ -27,43 +27,6 @@ import time
 
 from pymeasure.adapters import TelnetAdapter
 
-# compiled regular expression for finding numerical values in reply strings
-_reg_value = re.compile(r"\w+\s+=\s+(\w+)")
-
-
-def extract_value(reply):
-    """ get_process function for the Attocube console which for numerical
-    values typically return 'name = X.YZ unit'
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    r = _reg_value.search(reply)
-    if r:
-        return r.groups()[0]
-    else:
-        return reply
-
-
-def extract_float(reply):
-    """ get_process function for the Attocube console to obtain a float from
-    the reply
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    return float(extract_value(reply))
-
-
-def extract_int(reply):
-    """ get_process function for the Attocube console to obtain an integer from
-    the reply
-
-    :param reply: reply string
-    :returns: string with only the numerical value
-    """
-    return int(extract_value(reply))
-
 
 class AttocubeConsoleAdapter(TelnetAdapter):
     """ Adapter class for connecting to the Attocube Standard Console. This
@@ -74,9 +37,13 @@ class AttocubeConsoleAdapter(TelnetAdapter):
     :param passwd: password required to open the connection
     :param kwargs: Any valid key-word argument for TelnetAdapter
     """
+    # compiled regular expression for finding numerical values in reply strings
+    _reg_value = re.compile(r"\w+\s+=\s+(\w+)")
+
     def __init__(self, host, port, passwd, **kwargs):
         self.read_termination = '\r\n'
         self.write_termination = self.read_termination
+        kwargs.setdefault('preprocess_reply', self.extract_value)
         super().__init__(host, port, **kwargs)
         time.sleep(self.query_delay)
         super().read()  # clear messages sent upon opening the connection
@@ -89,6 +56,20 @@ class AttocubeConsoleAdapter(TelnetAdapter):
             raise Exception(f"Attocube authorization failed '{authmsg}'")
         # switch console echo off
         _ = self.ask('echo off')
+
+    def extract_value(self, reply):
+        """ preprocess_reply function for the Attocube console. This function
+        tries to extract <value> from 'name = <value> [unit]'. If <value> can
+        not be identified the original string is returned.
+
+        :param reply: reply string
+        :returns: string with only the numerical value, or the original string
+        """
+        r = self._reg_value.search(reply)
+        if r:
+            return r.groups()[0]
+        else:
+            return reply
 
     def check_acknowledgement(self, reply, msg=""):
         """ checks the last reply of the instrument to be 'OK', otherwise a

--- a/pymeasure/instruments/attocube/anc300.py
+++ b/pymeasure/instruments/attocube/anc300.py
@@ -25,10 +25,7 @@
 from math import inf
 
 from pymeasure.instruments import Instrument
-from pymeasure.instruments.attocube.adapters import (AttocubeConsoleAdapter,
-                                                     extract_float,
-                                                     extract_int,
-                                                     extract_value)
+from pymeasure.instruments.attocube.adapters import AttocubeConsoleAdapter
 from pymeasure.instruments.validators import (joined_validators,
                                               strict_discrete_set,
                                               strict_range)
@@ -75,30 +72,27 @@ class Axis(object):
             "getv", "setv %.3f",
             """ Amplitude of the stepping voltage in volts from 0 to 150 V. This
             property can be set. """,
-            validator=strict_range, values=[0, 150],
-            get_process=extract_float)
+            validator=strict_range, values=[0, 150])
 
     frequency = Instrument.control(
             "getf", "setf %.3f",
             """ Frequency of the stepping motion in Hertz from 1 to 10000 Hz.
             This property can be set. """,
             validator=strict_range, values=[1, 10000],
-            get_process=extract_int)
+            cast=int)
 
     mode = Instrument.control(
             "getm", "setm %s",
             """ Axis mode. This can be 'gnd', 'inp', 'cap', 'stp', 'off',
             'stp+', 'stp-'. Available modes depend on the actual axis model""",
             validator=strict_discrete_set,
-            values=['gnd', 'inp', 'cap', 'stp', 'off', 'stp+', 'stp-'],
-            get_process=extract_value)
+            values=['gnd', 'inp', 'cap', 'stp', 'off', 'stp+', 'stp-'])
 
     offset_voltage = Instrument.control(
             "geta", "seta %.3f",
             """ Offset voltage in Volts from 0 to 150 V.
             This property can be set. """,
-            validator=strict_range, values=[0, 150],
-            get_process=extract_float)
+            validator=strict_range, values=[0, 150])
 
     pattern_up = Instrument.control(
             "getpu", "setpu %s",
@@ -124,13 +118,11 @@ class Axis(object):
 
     output_voltage = Instrument.measurement(
             "geto",
-            """ Output voltage in volts.""",
-            get_process=extract_float)
+            """ Output voltage in volts.""")
 
     capacity = Instrument.measurement(
             "getc",
-            """ Saved capacity value in nF of the axis.""",
-            get_process=extract_float)
+            """ Saved capacity value in nF of the axis.""")
 
     stepu = Instrument.setting(
             "stepu %d",


### PR DESCRIPTION
using `preprocess_reply` the code of the `AttocubeConsoleAdapter` and ANC300 properties was simplified

* `extract_value` function was converted into a method of `AttocubeConsoleAdapter` and is now used as `preprocess_reply`
* `extract_float`, and `extract_int` are not needed anymore
* most properties now work without a dedicated `get_process`, also note that not a single property needed to deactivate the default `preprocess_reply`