### PR TITLE
Fixing #356: incompatible functions btw keithley2400 and keithley2450

### DIFF
--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -307,53 +307,37 @@ class Keithley2400(Instrument, KeithleyBuffer):
     # Filters #
     ###########
 
-    current_filter_type = Instrument.control(
-        ":SENS:CURR:AVER:TCON?", ":SENS:CURR:AVER:TCON %s",
-        """ A String property that controls the filter's type for the current.
+    filter_type = Instrument.control(
+        ":SENS:AVER:TCON?", ":SENS:AVER:TCON %s",
+        """ A String property that controls the filter's type.
         REP : Repeating filter
         MOV : Moving filter""",
         validator=strict_discrete_set,
         values=['REP', 'MOV'],
         map_values=False)
 
-    current_filter_count = Instrument.control(
-        ":SENS:CURR:AVER:COUNT?", ":SENS:CURR:AVER:COUNT %d",
+    filter_count = Instrument.control(
+        ":SENS:AVER:COUNT?", ":SENS:AVER:COUNT %d",
         """ A integer property that controls the number of readings that are 
         acquired and stored in the filter buffer for the averaging""",
         validator=truncated_range,
         values=[1, 2500],
         cast=int)
 
-    current_filter_state = Instrument.control(
-        ":SENS:CURR:AVER?", ":SENS:CURR:AVER %s",
+    filter_state = Instrument.control(
+        ":SENS:AVER?", ":SENS:AVER %s",
         """ A string property that controls if the filter is active.""",
         validator=strict_discrete_set,
         values=['ON', 'OFF'],
         map_values=False)
 
-    voltage_filter_type = Instrument.control(
-        ":SENS:VOLT:AVER:TCON?", ":SENS:VOLT:AVER:TCON %s",
-        """ A String property that controls the filter's type for the current.
-        REP : Repeating filter
-        MOV : Moving filter""",
-        validator=strict_discrete_set,
-        values=['REP', 'MOV'],
-        map_values=False)
-
-    voltage_filter_count = Instrument.control(
-        ":SENS:VOLT:AVER:COUNT?", ":SENS:VOLT:AVER:COUNT %d",
-        """ A integer property that controls the number of readings that are 
-        acquired and stored in the filter buffer for the averaging""",
-        validator=truncated_range,
-        values=[1, 2500],
-        cast=int)
 
     #####################
     # Output subsystem #
     #####################
 
-    current_output_off_state = Instrument.control(
-        ":OUTP:CURR:SMOD?", ":OUTP:CURR:SMOD %s",
+    output_off_state = Instrument.control(
+        ":OUTP:SMOD?", ":OUTP:SMOD %s",
         """ Select the output-off state of the SourceMeter.
         HIMP : output relay is open, disconnects external circuitry.
         NORM : V-Source is selected and set to 0V, Compliance is set to 0.5% 
@@ -366,20 +350,11 @@ class Keithley2400(Instrument, KeithleyBuffer):
         values=['HIMP', 'NORM', 'ZERO', 'GUAR'],
         map_values=False)
 
-    voltage_output_off_state = Instrument.control(
-        ":OUTP:VOLT:SMOD?", ":OUTP:VOLT:SMOD %s",
-        """ Select the output-off state of the SourceMeter.
-        HIMP : output relay is open, disconnects external circuitry.
-        NORM : V-Source is selected and set to 0V, Compliance is set to 0.5% 
-        full scale of the present current range.
-        ZERO : V-Source is selected and set to 0V, compliance is set to the 
-        programmed Source I value or to 0.5% full scale of the present current
-        range, whichever is greater.
-        GUAR : I-Source is selected and set to 0A""",
-        validator=strict_discrete_set,
-        values=['HIMP', 'NORM', 'ZERO', 'GUAR'],
-        map_values=False)
-
+    
+    ####################
+    # Methods        #
+    ####################
+    
     def __init__(self, adapter, **kwargs):
         super(Keithley2400, self).__init__(
             adapter, "Keithley 2400 SourceMeter", **kwargs

--- a/pymeasure/instruments/keithley/keithley2400.py
+++ b/pymeasure/instruments/keithley/keithley2400.py
@@ -321,7 +321,7 @@ class Keithley2400(Instrument, KeithleyBuffer):
         """ A integer property that controls the number of readings that are 
         acquired and stored in the filter buffer for the averaging""",
         validator=truncated_range,
-        values=[1, 2500],
+        values=[1, 100],
         cast=int)
 
     filter_state = Instrument.control(

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -123,6 +123,24 @@ class Keithley2450(Instrument, KeithleyBuffer):
         validator=truncated_range,
         values=[-1.05, 1.05]
     )
+    
+    source_current_delay = Instrument.control(
+        ":SOUR:CURR:DEL?", ":SOUR:CURR:DEL %g",
+        """ A floating point property that sets a manual delay for the source
+        after the output is turned on before a measurement is taken. When this
+        property is set, the auto delay is turned off. Valid values are
+        between 0 [seconds] and 999.9999 [seconds].""",
+        validator=truncated_range,
+        values=[0, 999.9999],
+    )
+
+    source_current_delay_auto = Instrument.control(
+        ":SOUR:CURR:DEL:AUTO?", ":SOUR:CURR:DEL:AUTO %d",
+        """ A boolean property that enables or disables auto delay. Valid
+        values are True and False. """,
+        values={True: 1, False: 0},
+        map_values=True,
+    )
 
     ###############
     # Voltage (V) #
@@ -171,6 +189,24 @@ class Keithley2450(Instrument, KeithleyBuffer):
         Auto-range is disabled when this property is set. """,
         validator=truncated_range,
         values=[-210, 210]
+    )
+    
+    source_voltage_delay = Instrument.control(
+        ":SOUR:VOLT:DEL?", ":SOUR:VOLT:DEL %g",
+        """ A floating point property that sets a manual delay for the source
+        after the output is turned on before a measurement is taken. When this
+        property is set, the auto delay is turned off. Valid values are
+        between 0 [seconds] and 999.9999 [seconds].""",
+        validator=truncated_range,
+        values=[0, 999.9999],
+    )
+
+    source_voltage_delay_auto = Instrument.control(
+        ":SOUR:VOLT:DEL:AUTO?", ":SOUR:VOLT:DEL:AUTO %d",
+        """ A boolean property that enables or disables auto delay. Valid
+        values are True and False. """,
+        values={True: 1, False: 0},
+        map_values=True,
     )
 
     ####################

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -261,7 +261,7 @@ class Keithley2450(Instrument, KeithleyBuffer):
         """ A integer property that controls the number of readings that are 
         acquired and stored in the filter buffer for the averaging""",
         validator=truncated_range,
-        values=[1, 2500],
+        values=[1, 100],
         cast=int)
 
     current_filter_state = Instrument.control(
@@ -285,7 +285,7 @@ class Keithley2450(Instrument, KeithleyBuffer):
         """ A integer property that controls the number of readings that are 
         acquired and stored in the filter buffer for the averaging""",
         validator=truncated_range,
-        values=[1, 2500],
+        values=[1, 100],
         cast=int)
 
     #####################

--- a/pymeasure/instruments/keithley/keithley2450.py
+++ b/pymeasure/instruments/keithley/keithley2450.py
@@ -243,6 +243,84 @@ class Keithley2450(Instrument, KeithleyBuffer):
         current, and resistance from the buffer data as a list. """
     )
 
+    ###########
+    # Filters #
+    ###########
+
+    current_filter_type = Instrument.control(
+        ":SENS:CURR:AVER:TCON?", ":SENS:CURR:AVER:TCON %s",
+        """ A String property that controls the filter's type for the current.
+        REP : Repeating filter
+        MOV : Moving filter""",
+        validator=strict_discrete_set,
+        values=['REP', 'MOV'],
+        map_values=False)
+
+    current_filter_count = Instrument.control(
+        ":SENS:CURR:AVER:COUNT?", ":SENS:CURR:AVER:COUNT %d",
+        """ A integer property that controls the number of readings that are 
+        acquired and stored in the filter buffer for the averaging""",
+        validator=truncated_range,
+        values=[1, 2500],
+        cast=int)
+
+    current_filter_state = Instrument.control(
+        ":SENS:CURR:AVER?", ":SENS:CURR:AVER %s",
+        """ A string property that controls if the filter is active.""",
+        validator=strict_discrete_set,
+        values=['ON', 'OFF'],
+        map_values=False)
+
+    voltage_filter_type = Instrument.control(
+        ":SENS:VOLT:AVER:TCON?", ":SENS:VOLT:AVER:TCON %s",
+        """ A String property that controls the filter's type for the current.
+        REP : Repeating filter
+        MOV : Moving filter""",
+        validator=strict_discrete_set,
+        values=['REP', 'MOV'],
+        map_values=False)
+
+    voltage_filter_count = Instrument.control(
+        ":SENS:VOLT:AVER:COUNT?", ":SENS:VOLT:AVER:COUNT %d",
+        """ A integer property that controls the number of readings that are 
+        acquired and stored in the filter buffer for the averaging""",
+        validator=truncated_range,
+        values=[1, 2500],
+        cast=int)
+
+    #####################
+    # Output subsystem #
+    #####################
+
+    current_output_off_state = Instrument.control(
+        ":OUTP:CURR:SMOD?", ":OUTP:CURR:SMOD %s",
+        """ Select the output-off state of the SourceMeter.
+        HIMP : output relay is open, disconnects external circuitry.
+        NORM : V-Source is selected and set to 0V, Compliance is set to 0.5% 
+        full scale of the present current range.
+        ZERO : V-Source is selected and set to 0V, compliance is set to the 
+        programmed Source I value or to 0.5% full scale of the present current
+        range, whichever is greater.
+        GUAR : I-Source is selected and set to 0A""",
+        validator=strict_discrete_set,
+        values=['HIMP', 'NORM', 'ZERO', 'GUAR'],
+        map_values=False)
+
+    voltage_output_off_state = Instrument.control(
+        ":OUTP:VOLT:SMOD?", ":OUTP:VOLT:SMOD %s",
+        """ Select the output-off state of the SourceMeter.
+        HIMP : output relay is open, disconnects external circuitry.
+        NORM : V-Source is selected and set to 0V, Compliance is set to 0.5% 
+        full scale of the present current range.
+        ZERO : V-Source is selected and set to 0V, compliance is set to the 
+        programmed Source I value or to 0.5% full scale of the present current
+        range, whichever is greater.
+        GUAR : I-Source is selected and set to 0A""",
+        validator=strict_discrete_set,
+        values=['HIMP', 'NORM', 'ZERO', 'GUAR'],
+        map_values=False)
+
+
     ####################
     # Methods        #
     ####################


### PR DESCRIPTION
Fixing issue [356](https://github.com/ralph-group/pymeasure/issues/356): incompatible functions introduced by PR [326](https://github.com/ralph-group/pymeasure/pull/326) in keithley2400 driver that actually belong to keithley2450. 

Corrected the functions in keithley2400 and added the corresponding ones in keithley2450.

_EDIT:_
To give more context: I am writing an IV program that should run on both Keithley2400 and 2450 series. While comparing the two syntax, I realized some functions are incorrect and/or missing in either one of the two drivers so I am trying to get them to a similar state, despite the slightly different syntax.